### PR TITLE
Model migration state explicitly

### DIFF
--- a/pkg/migration/migration.go
+++ b/pkg/migration/migration.go
@@ -1,0 +1,105 @@
+// Copyright 2016-2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migration
+
+import (
+	"encoding/json"
+	"os"
+)
+
+// MigrateMode represents the migration status or handling of a resource
+type MigrateMode string
+
+const (
+	// MigrateModeEmpty indicates the resource should be migrated normally
+	MigrateModeEmpty MigrateMode = ""
+	// MigrateModeSkip indicates the resource should be skipped in the migration
+	MigrateModeSkip MigrateMode = "skip"
+	// MigrateModeIgnoreNoState indicates that a resource that did not finish migrating state can be skipped
+	MigrateModeIgnoreNoState MigrateMode = "ignore-no-state"
+	// MigrateModeIgnoreNeedsUpdate indicates the resource that has state but wants to update on preview can be skipped
+	MigrateModeIgnoreNeedsUpdate MigrateMode = "ignore-needs-update"
+	// MigrateModeIgnoreNeedsUpdate indicates the resource that has state but wants to replace on preview can be skipped
+	MigrateModeIgnoreNeedsReplace MigrateMode = "ignore-needs-replace"
+)
+
+// MigrationFile represents the top-level structure of migration.json
+type MigrationFile struct {
+	Migration Migration `json:"migration"`
+}
+
+// Migration contains the configuration for migrating from Terraform to Pulumi
+type Migration struct {
+	// Path to the Terraform sources.
+	TFSources string `json:"tf-sources"`
+
+	// Path to the Pulumi sources.
+	PulumiSources string `json:"pulumi-sources"`
+
+	// Lists of Pulumi stacks corresponding to Terraform workspaces.
+	Stacks []Stack `json:"stacks"`
+}
+
+// Stack represents a mapping between a Terraform state and a Pulumi stack
+type Stack struct {
+	// File path to a Terraform state file. It can be in JSON format (ends with .json), or in raw binary format
+	// (ends with .tfstate).
+	TFState string `json:"tf-state"`
+
+	// Name of the Pulumi stack such as "dev".
+	PulumiStack string `json:"pulumi-stack"`
+
+	// Resource mappings.
+	Resources []Resource `json:"resources"`
+}
+
+// Resource represents a mapping between a Terraform resource and a Pulumi resource
+type Resource struct {
+	// Terraform resource address such as "aws_instance.app_server" or "aws_instance.web[0]".
+	TFAddr string `json:"tf-addr,omitempty"`
+
+	// Pulumi Resource URN such as "urn:pulumi:my-org:my-stack::my-project::aws:s3/bucket:Bucket::my-bucket" This
+	// may be empty if the resource is skipped from the migration.
+	URN string `json:"urn,omitempty"`
+
+	// Encode how the particular Terraform resource should be migrated, can it be skipped completely or can certain
+	// checks for this resource be ignored.
+	Migrate MigrateMode `json:"migrate,omitempty"`
+}
+
+// LoadMigration reads and parses a migration.json file
+func LoadMigration(path string) (*MigrationFile, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var mf MigrationFile
+	if err := json.Unmarshal(data, &mf); err != nil {
+		return nil, err
+	}
+
+	return &mf, nil
+}
+
+// Save writes the migration file to disk
+func (mf *MigrationFile) Save(path string) error {
+	data, err := json.MarshalIndent(mf, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(path, data, 0644)
+}

--- a/pkg/migration/migration_test.go
+++ b/pkg/migration/migration_test.go
@@ -1,0 +1,166 @@
+// Copyright 2016-2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migration
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadMigration(t *testing.T) {
+	t.Parallel()
+
+	t.Run("loads valid migration file", func(t *testing.T) {
+		t.Parallel()
+
+		// Create a temporary migration file
+		tmpDir := t.TempDir()
+		migrationPath := filepath.Join(tmpDir, "migration.json")
+
+		content := `{
+  "migration": {
+    "tf-sources": "./terraform",
+    "pulumi-sources": "./pulumi",
+    "stacks": [
+      {
+        "tf-state": "terraform.tfstate",
+        "pulumi-stack": "dev",
+        "resources": [
+          {
+            "tf-addr": "aws_instance.web",
+            "urn": "urn:pulumi:dev::my-project::aws:ec2/instance:Instance::web"
+          },
+          {
+            "tf-addr": "aws_s3_bucket.data",
+            "migrate": "skip"
+          }
+        ]
+      }
+    ]
+  }
+}`
+		err := os.WriteFile(migrationPath, []byte(content), 0644)
+		require.NoError(t, err)
+
+		// Load the migration
+		mf, err := LoadMigration(migrationPath)
+		require.NoError(t, err)
+		require.NotNil(t, mf)
+
+		// Verify the loaded data
+		assert.Equal(t, "./terraform", mf.Migration.TFSources)
+		assert.Equal(t, "./pulumi", mf.Migration.PulumiSources)
+		assert.Len(t, mf.Migration.Stacks, 1)
+
+		stack := mf.Migration.Stacks[0]
+		assert.Equal(t, "terraform.tfstate", stack.TFState)
+		assert.Equal(t, "dev", stack.PulumiStack)
+		assert.Len(t, stack.Resources, 2)
+
+		assert.Equal(t, "aws_instance.web", stack.Resources[0].TFAddr)
+		assert.Equal(t, "urn:pulumi:dev::my-project::aws:ec2/instance:Instance::web", stack.Resources[0].URN)
+		assert.Equal(t, MigrateModeEmpty, stack.Resources[0].Migrate)
+
+		assert.Equal(t, "aws_s3_bucket.data", stack.Resources[1].TFAddr)
+		assert.Equal(t, "", stack.Resources[1].URN)
+		assert.Equal(t, MigrateModeSkip, stack.Resources[1].Migrate)
+	})
+
+	t.Run("returns error for non-existent file", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := LoadMigration("/non/existent/path/migration.json")
+		assert.Error(t, err)
+	})
+
+	t.Run("returns error for invalid JSON", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		migrationPath := filepath.Join(tmpDir, "migration.json")
+
+		err := os.WriteFile(migrationPath, []byte("invalid json"), 0644)
+		require.NoError(t, err)
+
+		_, err = LoadMigration(migrationPath)
+		assert.Error(t, err)
+	})
+}
+
+func TestMigrationFile_Save(t *testing.T) {
+	t.Parallel()
+
+	t.Run("saves migration file correctly", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		migrationPath := filepath.Join(tmpDir, "migration.json")
+
+		// Create a migration file
+		mf := &MigrationFile{
+			Migration: Migration{
+				TFSources:     "./terraform",
+				PulumiSources: "./pulumi",
+				Stacks: []Stack{
+					{
+						TFState:     "terraform.tfstate",
+						PulumiStack: "prod",
+						Resources: []Resource{
+							{
+								TFAddr: "aws_instance.app",
+								URN:    "urn:pulumi:prod::my-project::aws:ec2/instance:Instance::app",
+							},
+							{
+								TFAddr:  "aws_s3_bucket.logs",
+								Migrate: MigrateModeIgnoreNoState,
+							},
+						},
+					},
+				},
+			},
+		}
+
+		// Save the file
+		err := mf.Save(migrationPath)
+		require.NoError(t, err)
+
+		// Verify the file exists
+		_, err = os.Stat(migrationPath)
+		require.NoError(t, err)
+
+		// Load it back and verify contents
+		loaded, err := LoadMigration(migrationPath)
+		require.NoError(t, err)
+
+		assert.Equal(t, mf.Migration.TFSources, loaded.Migration.TFSources)
+		assert.Equal(t, mf.Migration.PulumiSources, loaded.Migration.PulumiSources)
+		assert.Len(t, loaded.Migration.Stacks, 1)
+		assert.Equal(t, "prod", loaded.Migration.Stacks[0].PulumiStack)
+		assert.Len(t, loaded.Migration.Stacks[0].Resources, 2)
+		assert.Equal(t, MigrateModeIgnoreNoState, loaded.Migration.Stacks[0].Resources[1].Migrate)
+	})
+
+	t.Run("returns error for invalid path", func(t *testing.T) {
+		t.Parallel()
+
+		mf := &MigrationFile{}
+		err := mf.Save("/invalid/directory/that/does/not/exist/migration.json")
+		assert.Error(t, err)
+	})
+}


### PR DESCRIPTION
For larger programs explicit migration mapping is very important as it keeps an explicit track of which Pulumi resource is representing a given Terraform resource, and also if some resources are skipped (this can be enhanced by a skip reason). Having this explicit also enables a `diff` command that can compare a Pulumi project to a Terraform project and correlates resources to check if they are "fully migrated". The peculiarities of the diff command give rise to explicit skips here for resources that need update or replace.