### PR TITLE
Object from cty value

### DIFF
--- a/pkg/bridge/object_from_cty.go
+++ b/pkg/bridge/object_from_cty.go
@@ -1,0 +1,23 @@
+package pkg
+
+import (
+	"encoding/json"
+
+	"github.com/zclconf/go-cty/cty"
+	ctyjson "github.com/zclconf/go-cty/cty/json"
+)
+
+func objectFromCty(val cty.Value) (map[string]interface{}, error) {
+	bytes, err := ctyjson.Marshal(val, val.Type())
+	if err != nil {
+		return nil, err
+	}
+
+	var m map[string]interface{}
+	err = json.Unmarshal(bytes, &m)
+	if err != nil {
+		return nil, err
+	}
+
+	return m, nil
+}

--- a/pkg/bridge/object_from_cty_test.go
+++ b/pkg/bridge/object_from_cty_test.go
@@ -1,0 +1,62 @@
+package pkg
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestObjectFromCty(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		val  cty.Value
+		want map[string]interface{}
+	}{
+		{
+			name: "string",
+			val:  cty.ObjectVal(map[string]cty.Value{"x": cty.StringVal("y")}),
+			want: map[string]interface{}{"x": "y"},
+		},
+		{
+			name: "list",
+			val:  cty.ObjectVal(map[string]cty.Value{"x": cty.ListVal([]cty.Value{cty.StringVal("y")})}),
+			want: map[string]interface{}{"x": []interface{}{"y"}},
+		},
+		{
+			name: "set",
+			val:  cty.ObjectVal(map[string]cty.Value{"x": cty.SetVal([]cty.Value{cty.StringVal("y")})}),
+			want: map[string]interface{}{"x": []interface{}{"y"}},
+		},
+		{
+			name: "map",
+			val:  cty.ObjectVal(map[string]cty.Value{"x": cty.MapVal(map[string]cty.Value{"y": cty.StringVal("z")})}),
+			want: map[string]interface{}{"x": map[string]interface{}{"y": "z"}},
+		},
+		{
+			name: "object",
+			val:  cty.ObjectVal(map[string]cty.Value{"x": cty.ObjectVal(map[string]cty.Value{"y": cty.StringVal("z")})}),
+			want: map[string]interface{}{"x": map[string]interface{}{"y": "z"}},
+		},
+		{
+			name: "tuple",
+			val:  cty.ObjectVal(map[string]cty.Value{"x": cty.TupleVal([]cty.Value{cty.StringVal("y"), cty.StringVal("z")})}),
+			want: map[string]interface{}{"x": []interface{}{"y", "z"}},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := objectFromCty(test.val)
+			if err != nil {
+				t.Fatalf("failed to convert cty.Value to map[string]interface{}: %v", err)
+			}
+			if !reflect.DeepEqual(got, test.want) {
+				t.Errorf("expected %v, got %v", test.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This implements a simplified `cty.Value` -> `map[string]interface{}` conversion function. Simplified from the bridge implementation since we do not need to handle unknowns (TF state can't contain unknowns).

part of https://github.com/pulumi/pulumi-service/issues/34617