### PR TITLE
Pulumi type token

### DIFF
--- a/pkg/bridge/pulumi_type_token.go
+++ b/pkg/bridge/pulumi_type_token.go
@@ -1,0 +1,37 @@
+package bridge
+
+import (
+	"strings"
+	"unicode"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+)
+
+// copied from https://github.com/pulumi/pulumi-terraform-bridge/blob/main/pkg/tfbridge/provider.go#L425
+func PulumiTypeToken(tfTypeName string, pulumiProvider *info.Provider) (tokens.Type, error) {
+	resourceInfo := pulumiProvider.Resources[tfTypeName]
+	if resourceInfo.Tok != "" {
+		return resourceInfo.Tok, nil
+	}
+	camelName, pascalName := camelPascalPulumiName(tfTypeName, pulumiProvider)
+	pkgName := tokens.NewPackageToken(tokens.PackageName(tokens.IntoQName(pulumiProvider.Name)))
+	modTok := tokens.NewModuleToken(pkgName, tokens.ModuleName(camelName))
+	return tokens.NewTypeToken(modTok, tokens.TypeName(pascalName)), nil
+}
+
+// copied from pulumi-terraform-bridge/pkg/tfbridge/provider.go
+func camelPascalPulumiName(name string, prov *info.Provider) (string, string) {
+	prefix := prov.GetResourcePrefix() + "_"
+	contract.Assertf(strings.HasPrefix(name, prefix),
+		"Expected all Terraform resources in this module to have a '%v' prefix (%q)", prefix, name)
+	name = name[len(prefix):]
+	camel := tfbridge.TerraformToPulumiNameV2(name, nil, nil)
+	pascal := camel
+	if pascal != "" {
+		pascal = string(unicode.ToUpper(rune(pascal[0]))) + pascal[1:]
+	}
+	return camel, pascal
+}

--- a/pkg/bridge/pulumi_type_token_test.go
+++ b/pkg/bridge/pulumi_type_token_test.go
@@ -1,0 +1,54 @@
+package bridge
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPulumiTypeToken(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		tfTypeName     string
+		pulumiProvider *info.Provider
+		expectedToken  tokens.Type
+	}{
+		{
+			name:       "explicit token",
+			tfTypeName: "aws_apigatewayv2_api",
+			pulumiProvider: &info.Provider{
+				Name: "aws",
+				Resources: map[string]*info.Resource{
+					"aws_apigatewayv2_api": {
+						Tok: "aws:apigatewayApi:ApigatewayApi",
+					},
+				},
+			},
+			expectedToken: tokens.Type("aws:apigatewayApi:ApigatewayApi"),
+		},
+		{
+			name:       "implicit token",
+			tfTypeName: "aws_apigatewayv2_api",
+			pulumiProvider: &info.Provider{
+				Name: "aws",
+				Resources: map[string]*info.Resource{
+					"aws_apigatewayv2_api": {},
+				},
+			},
+			expectedToken: tokens.Type("aws:apigatewayv2Api:Apigatewayv2Api"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			token, err := PulumiTypeToken(test.tfTypeName, test.pulumiProvider)
+			require.NoError(t, err)
+			require.Equal(t, test.expectedToken, token)
+		})
+	}
+}


### PR DESCRIPTION
This adds code for translating a terraform resource type into a pulumi type token. This is mostly copied from the bridge since it's not public. We can decide to make it public later.