### PR TITLE
Move state file writing into pkg/

### DIFF
--- a/cmd/translate.go
+++ b/cmd/translate.go
@@ -4,9 +4,7 @@ Copyright © 2025 Pulumi Corporation
 package cmd
 
 import (
-	"encoding/json"
 	"fmt"
-	"os"
 
 	"github.com/pulumi/pulumi-terraform-migrate/pkg"
 	"github.com/spf13/cobra"
@@ -29,18 +27,9 @@ Example:
 		fmt.Printf("Converting Terraform state from: %s\n", inputPath)
 		fmt.Printf("Output will be written to: %s\n", outputFile)
 
-		data, err := pkg.TranslateState(inputPath, stackFolder)
+		err := pkg.TranslateAndWriteState(inputPath, stackFolder, outputFile)
 		if err != nil {
-			return fmt.Errorf("failed to convert Terraform state: %w", err)
-		}
-
-		bytes, err := json.Marshal(data)
-		if err != nil {
-			return fmt.Errorf("failed to marshal Pulumi state: %w", err)
-		}
-		err = os.WriteFile(outputFile, bytes, 0o600)
-		if err != nil {
-			return fmt.Errorf("failed to write Pulumi state: %w", err)
+			return fmt.Errorf("failed to convert and write Terraform state: %w", err)
 		}
 		return nil
 	},

--- a/pkg/state_adapter.go
+++ b/pkg/state_adapter.go
@@ -1,7 +1,9 @@
 package pkg
 
 import (
+	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/google/uuid"
@@ -21,6 +23,21 @@ type StackExport struct {
 	Version    int                  `json:"version"`
 }
 
+func TranslateAndWriteState(tofuStateFilePath string, pulumiProgramDir string, outputFilePath string) error {
+	stackExport, err := TranslateState(tofuStateFilePath, pulumiProgramDir)
+	if err != nil {
+		return err
+	}
+	bytes, err := json.Marshal(stackExport)
+	if err != nil {
+		return fmt.Errorf("failed to marshal stack export: %w", err)
+	}
+	err = os.WriteFile(outputFilePath, bytes, 0o600)
+	if err != nil {
+		return fmt.Errorf("failed to write stack export: %w", err)
+	}
+	return nil
+}
 
 func TranslateState(tofuStateFilePath string, pulumiProgramDir string) (*StackExport, error) {
 	tfState, err := tofu.LoadTerraformState(tofuStateFilePath)
@@ -123,7 +140,5 @@ func convertResourceState(res *tfjson.StateResource, pulumiProviders map[provide
 		Inputs:  inputs,
 		Outputs: props,
 		Name:    res.Name,
-		// Parent:   stackUrn,
-		// Provider: providerUrn,
 	}, nil
 }


### PR DESCRIPTION
This PR just moves the code for writing out the state file into `pkg/` so that we can test it. This leaves the code in `cmd` as thin as possible.

part of https://github.com/pulumi/pulumi-service/issues/35412