### PR TITLE
End-to-end preview test

### DIFF
--- a/pkg/pulumi_providers.go
+++ b/pkg/pulumi_providers.go
@@ -92,6 +92,10 @@ func GetProviderInputs(providerName string) (resource.PropertyMap, error) {
 		return resource.PropertyMap{
 			"version": resource.NewProperty("0.3.5"),
 		}, nil
+	case "random":
+		return resource.PropertyMap{
+			"version": resource.NewProperty("4.18.1"),
+		}, nil
 	}
 	return nil, fmt.Errorf("unsupported provider: %s", providerName)
 }

--- a/test/testdata/TestTranslateBasic.golden
+++ b/test/testdata/TestTranslateBasic.golden
@@ -1,0 +1,18 @@
+`Previewing update (dev)
+
+View Live: https://app.pulumi.com/pulumi/pulumi-stack-3633370916/dev/previews/73e462c9-6434-45de-8c49-dec43eb607f0
+
+Loading policy packs...
+
+@ Previewing update....
+
+ -  random:index:RandomString random delete
+    pulumi:pulumi:Stack pulumi-stack-3633370916-dev
+Policies:
+    ✅ pulumi-internal-policies@v0.0.6
+
+Resources:
+    - 1 to delete
+    1 unchanged
+
+`

--- a/test/testdata/tf_random_stack/main.tf
+++ b/test/testdata/tf_random_stack/main.tf
@@ -1,0 +1,5 @@
+resource "random_string" "random" {
+  length           = 16
+  special          = true
+  override_special = "/@£$"
+}

--- a/test/translate_test.go
+++ b/test/translate_test.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/hexops/autogold/v2"
+	"github.com/pulumi/pulumi-terraform-migrate/pkg"
+	"github.com/stretchr/testify/require"
+)
+
+func skipIfCI(t *testing.T) {
+	t.Helper()
+	if os.Getenv("CI") == "true" {
+		t.Skip("Skipping test in CI: TODO: set up pulumi credentials in CI")
+	}
+}
+
+func runCommand(t *testing.T, dir string, command string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command(command, args...)
+	cmd.Dir = dir
+	output, err := cmd.Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			t.Fatalf("failed to run command %s %v, error: %v, output: %s", command, args, err, string(exitErr.Stderr))
+		}
+		t.Fatalf("failed to run command %s %v, error: %v", command, args, err)
+	}
+	return string(output)
+}
+
+func setupTFStack(t *testing.T, terraformSourcesPath string) string {
+	dir, err := os.MkdirTemp("", "tf-stack-")
+	require.NoError(t, err)
+	t.Logf("Terraform stack directory: %s", dir)
+	sourceDir := os.DirFS(terraformSourcesPath)
+	os.CopyFS(dir, sourceDir)
+
+	_ = runCommand(t, dir, "tofu", "init")
+	_ = runCommand(t, dir, "tofu", "apply", "-auto-approve")
+	return filepath.Join(dir, "terraform.tfstate")
+}
+
+func createPulumiStack(t *testing.T) string {
+	dir, err := os.MkdirTemp("", "pulumi-stack-")
+	require.NoError(t, err)
+	t.Logf("Pulumi stack directory: %s", dir)
+
+	_ = runCommand(t, dir, "pulumi", "new", "typescript", "--dir", dir, "--yes")
+	_ = runCommand(t, dir, "pulumi", "up", "--yes")
+	return dir
+}
+
+func TestTranslateBasic(t *testing.T) {
+	skipIfCI(t)
+	statePath := setupTFStack(t, "testdata/tf_random_stack")
+
+	stackFolder := createPulumiStack(t)
+
+	err := pkg.TranslateAndWriteState(statePath, stackFolder, filepath.Join(stackFolder, "state.json"))
+	require.NoError(t, err)
+
+	_ = runCommand(t, stackFolder, "pulumi", "stack", "import", "--file", filepath.Join(stackFolder, "state.json"))
+	output := runCommand(t, stackFolder, "pulumi", "preview")
+
+	autogold.ExpectFile(t, output)
+}


### PR DESCRIPTION
This PR adds a simple end-to-end test for the state translation which:
1. Sets up a TF stack, runs `apply`
2. Sets up a Pulumi stack., runs `up`
3. Translates the state over
4. Runs `preview` and records the output to verify the resource is there and the state is readable.

part of https://github.com/pulumi/pulumi-service/issues/35412