### PR TITLE
Ensure not panic when no current stack selected

### DIFF
--- a/cmd/translate.go
+++ b/cmd/translate.go
@@ -28,7 +28,7 @@ Example:
 		fmt.Printf("Converting Terraform state from: %s\n", inputPath)
 		fmt.Printf("Output will be written to: %s\n", outputFile)
 
-		err := pkg.TranslateAndWriteState(inputPath, stackFolder, outputFile, requiredProvidersOutputFile)
+		err := pkg.TranslateAndWriteState(cmd.Context(), inputPath, stackFolder, outputFile, requiredProvidersOutputFile)
 		if err != nil {
 			return fmt.Errorf("failed to convert and write Terraform state: %w", err)
 		}

--- a/pkg/pulumi_state.go
+++ b/pkg/pulumi_state.go
@@ -65,15 +65,14 @@ type DeploymentResult struct {
 	StackName   string
 }
 
-func GetDeployment(outputFolder string) (*DeploymentResult, error) {
-	ctx := context.Background()
-	workspace, err := auto.NewLocalWorkspace(ctx, auto.WorkDir(outputFolder))
+func GetDeployment(ctx context.Context, pulumiProjectDir string) (*DeploymentResult, error) {
+	workspace, err := auto.NewLocalWorkspace(ctx, auto.WorkDir(pulumiProjectDir))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create workspace: %w", err)
 	}
 
 	// TODO[pulumi/pulumi#21266]: Use automation API to get the selected stack name once the issue is fixed.
-	stackName, err := getStackName(outputFolder)
+	stackName, err := getStackName(pulumiProjectDir)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get stack name: %w", err)
 	}

--- a/pkg/state_adapter.go
+++ b/pkg/state_adapter.go
@@ -1,6 +1,7 @@
 package pkg
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"maps"
@@ -32,9 +33,13 @@ type RequiredProviderExport struct {
 }
 
 func TranslateAndWriteState(
-	tofuStateFilePath string, pulumiProgramDir string, outputFilePath string, requiredProvidersOutputFilePath string,
+	ctx context.Context,
+	tofuStateFilePath string,
+	pulumiProgramDir string,
+	outputFilePath string,
+	requiredProvidersOutputFilePath string,
 ) error {
-	res, err := TranslateState(tofuStateFilePath, pulumiProgramDir)
+	res, err := TranslateState(ctx, tofuStateFilePath, pulumiProgramDir)
 	if err != nil {
 		return err
 	}
@@ -69,7 +74,7 @@ type TranslateStateResult struct {
 	RequiredProviders []*info.Provider
 }
 
-func TranslateState(tofuStateFilePath string, pulumiProgramDir string) (*TranslateStateResult, error) {
+func TranslateState(ctx context.Context, tofuStateFilePath string, pulumiProjectDir string) (*TranslateStateResult, error) {
 	tfState, err := tofu.LoadTerraformState(tofuStateFilePath)
 	if err != nil {
 		return nil, err
@@ -85,7 +90,7 @@ func TranslateState(tofuStateFilePath string, pulumiProgramDir string) (*Transla
 		return nil, err
 	}
 
-	deployment, err := GetDeployment(pulumiProgramDir)
+	deployment, err := GetDeployment(ctx, pulumiProjectDir)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/state_adapter_test.go
+++ b/pkg/state_adapter_test.go
@@ -1,6 +1,7 @@
 package pkg
 
 import (
+	"context"
 	"os"
 	"testing"
 
@@ -24,7 +25,7 @@ func TestConvertSimple(t *testing.T) {
 		t.Skip("Skipping test in CI: TODO: set up pulumi credentials in CI")
 	}
 	stackFolder := createPulumiStack(t)
-	data, err := TranslateState("testdata/bucket_state.json", stackFolder)
+	data, err := TranslateState(context.Background(), "testdata/bucket_state.json", stackFolder)
 	if err != nil {
 		t.Fatalf("failed to convert Terraform state: %v", err)
 	}
@@ -37,7 +38,7 @@ func TestConvertWithDependencies(t *testing.T) {
 		t.Skip("Skipping test in CI: TODO: set up pulumi credentials in CI")
 	}
 	stackFolder := createPulumiStack(t)
-	res, err := TranslateState("testdata/bucket_state.json", stackFolder)
+	res, err := TranslateState(context.Background(), "testdata/bucket_state.json", stackFolder)
 	if err != nil {
 		t.Fatalf("failed to convert Terraform state: %v", err)
 	}
@@ -53,10 +54,10 @@ func TestConvertInvolved(t *testing.T) {
 		t.Skip("Skipping test in CI: TODO: set up pulumi credentials in CI")
 	}
 	stackFolder := createPulumiStack(t)
-	data, err := TranslateState("testdata/tofu_state.json", stackFolder)
+	data, err := TranslateState(context.Background(), "testdata/tofu_state.json", stackFolder)
 	if err != nil {
 		t.Fatalf("failed to convert Terraform state: %v", err)
 	}
 
-	autogold.ExpectFile(t, data)
+	autogold.ExpectFile(t, data.Export)
 }

--- a/test/translate_test.go
+++ b/test/translate_test.go
@@ -94,7 +94,7 @@ func TestTranslateBasic(t *testing.T) {
 
 	ctx := context.Background()
 
-	err := pkg.TranslateAndWriteState(statePath, stackFolder, filepath.Join(stackFolder, "state.json"), "")
+	err := pkg.TranslateAndWriteState(context.Background(), statePath, stackFolder, filepath.Join(stackFolder, "state.json"), "")
 	require.NoError(t, err)
 
 	_ = runCommand(t, stackFolder, "pulumi", "stack", "import", "--file", filepath.Join(stackFolder, "state.json"))
@@ -126,7 +126,7 @@ func TestTranslateBasicWithDependencies(t *testing.T) {
 	statePath := setupTFStack(t, "testdata/tf_random_stack")
 	stackFolder, _ := createPulumiStack(t)
 
-	err := pkg.TranslateAndWriteState(statePath, stackFolder, filepath.Join(stackFolder, "state.json"), filepath.Join(stackFolder, "dependencies.json"))
+	err := pkg.TranslateAndWriteState(context.Background(), statePath, stackFolder, filepath.Join(stackFolder, "state.json"), filepath.Join(stackFolder, "dependencies.json"))
 	require.NoError(t, err)
 
 	dependencies, err := os.ReadFile(filepath.Join(stackFolder, "dependencies.json"))
@@ -142,7 +142,7 @@ func TestTranslateBasicWithEdit(t *testing.T) {
 	statePath := setupTFStack(t, "testdata/tf_random_stack")
 	stackFolder, stackName := createPulumiStack(t)
 
-	err := pkg.TranslateAndWriteState(statePath, stackFolder, filepath.Join(stackFolder, "state.json"), "")
+	err := pkg.TranslateAndWriteState(context.Background(), statePath, stackFolder, filepath.Join(stackFolder, "state.json"), "")
 	require.NoError(t, err)
 
 	_ = runCommand(t, stackFolder, "pulumi", "stack", "import", "--file", filepath.Join(stackFolder, "state.json"))
@@ -198,7 +198,7 @@ func TestTranslateWithDependency(t *testing.T) {
 	statePath := setupTFStack(t, "testdata/tf_dependency_stack")
 	stackFolder, stackName := createPulumiStack(t)
 
-	err := pkg.TranslateAndWriteState(statePath, stackFolder, filepath.Join(stackFolder, "state.json"), "")
+	err := pkg.TranslateAndWriteState(context.Background(), statePath, stackFolder, filepath.Join(stackFolder, "state.json"), "")
 	require.NoError(t, err)
 
 	_ = runCommand(t, stackFolder, "pulumi", "stack", "import", "--file", filepath.Join(stackFolder, "state.json"))
@@ -217,7 +217,7 @@ func TestTranslateAWSStack(t *testing.T) {
 	statePath := setupTFStack(t, "testdata/tf_aws_stack")
 	stackFolder, stackName := createPulumiStack(t)
 
-	err := pkg.TranslateAndWriteState(statePath, stackFolder, filepath.Join(stackFolder, "state.json"), "")
+	err := pkg.TranslateAndWriteState(context.Background(), statePath, stackFolder, filepath.Join(stackFolder, "state.json"), "")
 	require.NoError(t, err)
 
 	_ = runCommand(t, stackFolder, "pulumi", "stack", "import", "--file", filepath.Join(stackFolder, "state.json"))
@@ -238,7 +238,7 @@ func TestTranslateAWSStackWithEdit(t *testing.T) {
 	statePath := setupTFStack(t, "testdata/tf_aws_stack")
 	stackFolder, stackName := createPulumiStack(t)
 
-	err := pkg.TranslateAndWriteState(statePath, stackFolder, filepath.Join(stackFolder, "state.json"), "")
+	err := pkg.TranslateAndWriteState(context.Background(), statePath, stackFolder, filepath.Join(stackFolder, "state.json"), "")
 	require.NoError(t, err)
 
 	_ = runCommand(t, stackFolder, "pulumi", "stack", "import", "--file", filepath.Join(stackFolder, "state.json"))


### PR DESCRIPTION
Originally a fix for a small panic encountered when there is no current Pulumi stack selected in the Pulumi project. Subsequent changes to main have removed the problem, this PR just retains additional coupe of small tests. 