### PR TITLE
Fix automation API issue with stack name

### DIFF
--- a/pkg/pulumi_state_test.go
+++ b/pkg/pulumi_state_test.go
@@ -1,11 +1,14 @@
 package pkg
 
 import (
+	"os"
+	"os/exec"
 	"testing"
 
 	"github.com/hexops/autogold/v2"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/stretchr/testify/require"
 )
 
 func TestInsertResourcesIntoDeployment(t *testing.T) {
@@ -82,4 +85,40 @@ func TestInsertResourcesIntoDeployment(t *testing.T) {
 	}
 
 	autogold.ExpectFile(t, data)
+}
+
+func runCommand(t *testing.T, dir string, command string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command(command, args...)
+	cmd.Dir = dir
+	output, err := cmd.Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			t.Fatalf("failed to run command %s %v, error: %v, output: %s, stdout: %s", command, args, err, string(exitErr.Stderr), output)
+		}
+		t.Fatalf("failed to run command %s %v, error: %v", command, args, err)
+	}
+	return string(output)
+}
+
+func skipIfCI(t *testing.T) {
+	t.Helper()
+	if os.Getenv("CI") == "true" {
+		t.Skip("Skipping test in CI: TODO: set up pulumi credentials in CI")
+	}
+}
+
+func TestGetDeployment(t *testing.T) {
+	skipIfCI(t)
+	testDir, err := os.MkdirTemp("", "test-deployment-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(testDir)
+
+	_ = runCommand(t, testDir, "pulumi", "new", "typescript", "--yes")
+	_ = runCommand(t, testDir, "pulumi", "stack", "select", "dev")
+	_ = runCommand(t, testDir, "pulumi", "up", "--yes")
+
+	deployment, err := GetDeployment(testDir)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(deployment.Resources))
 }


### PR DESCRIPTION
Looks like the automation API `Stack` function doesn't do what I think it should do. Instead use the pulumi CLI to get the currently selected stack name.