### PR TITLE
Fix hardcoded project and stack name

### DIFF
--- a/pkg/pulumi_state_test.go
+++ b/pkg/pulumi_state_test.go
@@ -121,5 +121,5 @@ func TestGetDeployment(t *testing.T) {
 
 	deployment, err := GetDeployment(testDir)
 	require.NoError(t, err)
-	require.Equal(t, 1, len(deployment.Resources))
+	require.Equal(t, 1, len(deployment.Deployment.Resources))
 }

--- a/pkg/state_adapter.go
+++ b/pkg/state_adapter.go
@@ -89,7 +89,8 @@ func TranslateState(tofuStateFilePath string, pulumiProgramDir string) (*Transla
 	if err != nil {
 		return nil, err
 	}
-	editedDeployment, err := InsertResourcesIntoDeployment(pulumiState, "dev", "example", deployment)
+
+	editedDeployment, err := InsertResourcesIntoDeployment(pulumiState, deployment.StackName, deployment.ProjectName, deployment.Deployment)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
No longer assume "dev" and "example" literals. 