### PR TITLE
ci: tests can now have AWS account access

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,14 @@ name: Test
 on:
   pull_request:
 
+env:
+  AWS_REGION: us-west-2
+  OIDC_ROLE_ARN: ${{ secrets.OIDC_ROLE_ARN }}
+
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   test:
     name: Run Go Tests
@@ -10,6 +18,21 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Generate Pulumi Access Token
+        id: generate_pulumi_token
+        uses: pulumi/auth-actions@1c89817aab0c66407723cdef72b05266e7376640 # v1.0.1
+        with:
+          organization: pulumi
+          requested-token-type: urn:pulumi:token-type:access_token:organization
+          export-environment-variables: false
+
+      - name: Export AWS Credentials
+        uses: pulumi/esc-action@efb0bc8946938f0dfbfa00e829196ec95f0d0ea7 # v1.4.0
+        env:
+          PULUMI_ACCESS_TOKEN: ${{ steps.generate_pulumi_token.outputs.pulumi-access-token }}
+        with:
+          environment: logins/pulumi-ci
 
       - name: Set up Go
         uses: actions/setup-go@v5


### PR DESCRIPTION
The setup has been taken from pulumi-aws by example.