### PR TITLE
chore: mark tests Parallel

### DIFF
--- a/pkg/bridgedproviders/install_test.go
+++ b/pkg/bridgedproviders/install_test.go
@@ -28,6 +28,7 @@ import (
 // This is an integration test that actually downloads and installs a provider.
 // It's skipped by default but can be enabled for manual testing.
 func TestInstallProvider_Integration(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	// Install a small provider like random to the standard Pulumi home
@@ -56,6 +57,7 @@ func TestInstallProvider_Integration(t *testing.T) {
 }
 
 func TestInstallProvider_RequiresName(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	_, err := InstallProvider(ctx, InstallProviderOptions{
@@ -67,6 +69,7 @@ func TestInstallProvider_RequiresName(t *testing.T) {
 }
 
 func TestInstallProvider_RequiresVersion(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	_, err := InstallProvider(ctx, InstallProviderOptions{
@@ -78,6 +81,7 @@ func TestInstallProvider_RequiresVersion(t *testing.T) {
 }
 
 func TestInstallProvider_InvalidVersion(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	_, err := InstallProvider(ctx, InstallProviderOptions{
@@ -90,6 +94,7 @@ func TestInstallProvider_InvalidVersion(t *testing.T) {
 }
 
 func TestGetProviderBinaryPath(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name       string
 		pluginDir  string
@@ -136,6 +141,7 @@ func TestGetProviderBinaryPath(t *testing.T) {
 }
 
 func TestGetInstalledProviderPath_RequiresName(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	_, err := GetInstalledProviderPath(ctx, "", "v4.16.7")
@@ -145,6 +151,7 @@ func TestGetInstalledProviderPath_RequiresName(t *testing.T) {
 }
 
 func TestGetInstalledProviderPath_RequiresVersion(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	_, err := GetInstalledProviderPath(ctx, "random", "")
@@ -154,6 +161,7 @@ func TestGetInstalledProviderPath_RequiresVersion(t *testing.T) {
 }
 
 func TestGetInstalledProviderPath_NotFound(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	providerName := "nonexistent"
 	version := "1.0.0"

--- a/pkg/bridgedproviders/mapping_test.go
+++ b/pkg/bridgedproviders/mapping_test.go
@@ -22,6 +22,7 @@ import (
 // This is an example test showing how GetMappingFromBinary would be used.
 // To run this test, you would need a real Pulumi provider binary that implements GetMapping.
 func TestGetMappingFromBinary_Example(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	// Install a small provider like random
@@ -54,6 +55,7 @@ func TestGetMappingFromBinary_Example(t *testing.T) {
 }
 
 func TestGetMappingFromBinary_RequiresBinaryPath(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	_, err := GetMappingFromBinary(ctx, "", GetMappingOptions{
@@ -65,6 +67,7 @@ func TestGetMappingFromBinary_RequiresBinaryPath(t *testing.T) {
 }
 
 func TestGetMappingFromBinary_RequiresKey(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	_, err := GetMappingFromBinary(ctx, "/path/to/binary", GetMappingOptions{

--- a/pkg/providermap/providermap_test.go
+++ b/pkg/providermap/providermap_test.go
@@ -26,6 +26,7 @@ import (
 )
 
 func TestRecommendPulumiProvider(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name                         string
 		input                        TerraformProvider
@@ -168,6 +169,7 @@ func TestRecommendPulumiProvider(t *testing.T) {
 }
 
 func TestProviderMappingUsesProvidersThatExist(t *testing.T) {
+	t.Parallel()
 	for k := range providerMapping {
 		parts := strings.Split(string(k), "/")
 		ok, err := checkProviderExists(context.Background(), parts[0], parts[1], parts[2])

--- a/pkg/pulumi_providers_test.go
+++ b/pkg/pulumi_providers_test.go
@@ -43,6 +43,7 @@ resource "random_string" "random" {
 }
 
 func TestGetPulumiProvidersForTerraformState(t *testing.T) {
+	t.Parallel()
 	tmpDir, err := os.MkdirTemp("", "tofu-test-*")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpDir)

--- a/pkg/pulumi_state_test.go
+++ b/pkg/pulumi_state_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestInsertResourcesIntoDeployment(t *testing.T) {
+	t.Parallel()
 	data, err := InsertResourcesIntoDeployment(&PulumiState{
 		Providers: []PulumiResource{
 			{

--- a/pkg/state_adapter_test.go
+++ b/pkg/state_adapter_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestConvertSimple(t *testing.T) {
+	t.Parallel()
 	if os.Getenv("CI") == "true" {
 		t.Skip("Skipping test in CI: TODO: set up pulumi credentials in CI")
 	}
@@ -20,6 +21,7 @@ func TestConvertSimple(t *testing.T) {
 }
 
 func TestConvertInvolved(t *testing.T) {
+	t.Parallel()
 	if os.Getenv("CI") == "true" {
 		t.Skip("Skipping test in CI: TODO: set up pulumi credentials in CI")
 	}

--- a/pkg/tofu/loader_test.go
+++ b/pkg/tofu/loader_test.go
@@ -98,6 +98,7 @@ resource "null_resource" "test" {
 }
 
 func TestReadTerraformStateJSON(t *testing.T) {
+	t.Parallel()
 	tmpDir, err := os.MkdirTemp("", "tofu-test-*")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpDir)
@@ -116,6 +117,7 @@ func TestReadTerraformStateJSON(t *testing.T) {
 }
 
 func TestReadTerraformStateJSON_InvalidFile(t *testing.T) {
+	t.Parallel()
 	tmpDir, err := os.MkdirTemp("", "tofu-test-*")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpDir)
@@ -136,6 +138,7 @@ func TestReadTerraformStateJSON_InvalidFile(t *testing.T) {
 }
 
 func TestLoadTerraformState_JSON(t *testing.T) {
+	t.Parallel()
 	tmpDir, err := os.MkdirTemp("", "tofu-test-*")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpDir)
@@ -150,6 +153,7 @@ func TestLoadTerraformState_JSON(t *testing.T) {
 }
 
 func TestLoadTerraformState_Tfstate(t *testing.T) {
+	t.Parallel()
 	skipIfTofuNotAvailable(t)
 
 	tmpDir, err := os.MkdirTemp("", "tofu-test-*")
@@ -167,6 +171,7 @@ func TestLoadTerraformState_Tfstate(t *testing.T) {
 }
 
 func TestLoadTerraformState_UnsupportedFormat(t *testing.T) {
+	t.Parallel()
 	tmpDir, err := os.MkdirTemp("", "tofu-test-*")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpDir)
@@ -182,6 +187,7 @@ func TestLoadTerraformState_UnsupportedFormat(t *testing.T) {
 }
 
 func TestLoadBinaryStateWithTofu(t *testing.T) {
+	t.Parallel()
 	skipIfTofuNotAvailable(t)
 
 	tmpDir, err := os.MkdirTemp("", "tofu-test-*")
@@ -198,6 +204,7 @@ func TestLoadBinaryStateWithTofu(t *testing.T) {
 }
 
 func TestLoadBinaryStateWithTofu_NonExistentFile(t *testing.T) {
+	t.Parallel()
 	skipIfTofuNotAvailable(t)
 
 	tmpDir, err := os.MkdirTemp("", "tofu-test-*")

--- a/pkg/tofu/state_to_cty_test.go
+++ b/pkg/tofu/state_to_cty_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestResourceToCtyValue(t *testing.T) {
+	t.Parallel()
 	state, err := LoadTerraformState("testdata/apigatway_state.json")
 	if err != nil {
 		t.Fatalf("failed to read Terraform resource: %v", err)

--- a/pkg/tofu/visitors_test.go
+++ b/pkg/tofu/visitors_test.go
@@ -23,12 +23,14 @@ import (
 )
 
 func TestDefaultVisitOptions(t *testing.T) {
+	t.Parallel()
 	opts := &VisitOptions{}
 	assert.NotNil(t, opts)
 	assert.False(t, opts.IncludeDataSources, "Data sources should be skipped by default (zero value)")
 }
 
 func TestVisitResources_NilState(t *testing.T) {
+	t.Parallel()
 	visited := 0
 	err := VisitResources(nil, func(res *tfjson.StateResource) error {
 		visited++
@@ -39,6 +41,7 @@ func TestVisitResources_NilState(t *testing.T) {
 }
 
 func TestVisitResources_EmptyState(t *testing.T) {
+	t.Parallel()
 	state := &tfjson.State{}
 	visited := 0
 	err := VisitResources(state, func(res *tfjson.StateResource) error {
@@ -50,6 +53,7 @@ func TestVisitResources_EmptyState(t *testing.T) {
 }
 
 func TestVisitResources_SkipDataSources(t *testing.T) {
+	t.Parallel()
 	state := &tfjson.State{
 		Values: &tfjson.StateValues{
 			RootModule: &tfjson.StateModule{
@@ -88,6 +92,7 @@ func TestVisitResources_SkipDataSources(t *testing.T) {
 }
 
 func TestVisitResources_IncludeDataSources(t *testing.T) {
+	t.Parallel()
 	state := &tfjson.State{
 		Values: &tfjson.StateValues{
 			RootModule: &tfjson.StateModule{
@@ -120,6 +125,7 @@ func TestVisitResources_IncludeDataSources(t *testing.T) {
 }
 
 func TestVisitResources_WithChildModules(t *testing.T) {
+	t.Parallel()
 	state := &tfjson.State{
 		Values: &tfjson.StateValues{
 			RootModule: &tfjson.StateModule{
@@ -187,6 +193,7 @@ func TestVisitResources_WithChildModules(t *testing.T) {
 }
 
 func TestVisitResources_VisitorError(t *testing.T) {
+	t.Parallel()
 	state := &tfjson.State{
 		Values: &tfjson.StateValues{
 			RootModule: &tfjson.StateModule{

--- a/test/translate_test.go
+++ b/test/translate_test.go
@@ -82,6 +82,7 @@ func replaceIndexTs(t *testing.T, stackFolder string, indexTsPath string) {
 }
 
 func TestTranslateBasic(t *testing.T) {
+	t.Parallel()
 	skipIfCI(t)
 	statePath := setupTFStack(t, "testdata/tf_random_stack")
 	stackFolder, stackName := createPulumiStack(t)
@@ -100,6 +101,7 @@ func TestTranslateBasic(t *testing.T) {
 }
 
 func TestTranslateBasicWithEdit(t *testing.T) {
+	t.Parallel()
 	skipIfCI(t)
 	statePath := setupTFStack(t, "testdata/tf_random_stack")
 	stackFolder, stackName := createPulumiStack(t)
@@ -123,6 +125,7 @@ func TestTranslateBasicWithEdit(t *testing.T) {
 }
 
 func TestTranslateWithDependency(t *testing.T) {
+	t.Parallel()
 	skipIfCI(t)
 	statePath := setupTFStack(t, "testdata/tf_dependency_stack")
 	stackFolder, stackName := createPulumiStack(t)
@@ -141,6 +144,7 @@ func TestTranslateWithDependency(t *testing.T) {
 }
 
 func TestTranslateAWSStack(t *testing.T) {
+	t.Parallel()
 	skipIfCI(t)
 	statePath := setupTFStack(t, "testdata/tf_aws_stack")
 	stackFolder, stackName := createPulumiStack(t)
@@ -160,6 +164,7 @@ func TestTranslateAWSStack(t *testing.T) {
 }
 
 func TestTranslateAWSStackWithEdit(t *testing.T) {
+	t.Parallel()
 	skipIfCI(t)
 
 	statePath := setupTFStack(t, "testdata/tf_aws_stack")


### PR DESCRIPTION
Mark Go tests as `t.Parallel()` to speed up CI a little bit.