### PR TITLE
Use release automation from pulumi-tool-cdk-importer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,28 +1,32 @@
 name: Release
+
 on:
-  release:
-    types: [created]
+  push:
+    tags:
+      - 'v*'
 
 permissions:
   contents: write
   packages: write
 
 jobs:
-  release-amd64:
-    runs-on: ubuntu-latest
+  publish:
+    name: Publish
+    runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: wangyoucao577/go-release-action@v1
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      - name: Unshallow clone for tags
+        run: git fetch --prune --unshallow --tags || true
+      - name: Install Go
+        uses: actions/setup-go@v5
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          goos: linux
-          goarch: amd64
-  release-arm64:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: wangyoucao577/go-release-action@v1
+          go-version: 1.22.x
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          goos: linux
-          goarch: arm64
+          distribution: goreleaser
+          version: latest
+          args: release --clean -p 10 -f .goreleaser.yml --skip=validate --timeout 60m0s
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,25 @@
+dist: goreleaser
+project_name: pulumi-tool-terraform-migrate
+version: 2
+snapshot:
+  version_template: "{{ .Version }}-SNAPSHOT"
+checksum:
+  name_template: "{{ .ProjectName }}-{{ .Version }}-checksums.txt"
+archives:
+- id: archive
+  name_template: '{{ .Binary }}-{{ .Tag }}-{{ .Os }}-{{ .Arch }}'
+builds:
+- id: pulumi-tool-terraform-migrate
+  binary: pulumi-tool-terraform-migrate
+  goarch:
+  - amd64
+  - arm64
+  goos:
+  - darwin
+  - windows
+  - linux
+  ldflags:
+  - -s
+  - -w
+  - -X github.com/pulumi/pulumi-tool-terraform-migrate/pkg/version.Version={{.Tag}}
+  main: .

--- a/pkg/version.go
+++ b/pkg/version.go
@@ -1,0 +1,19 @@
+// Copyright 2016-2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package version
+
+// Version is the version of the pulumi-tool-terraform-migrate binary.
+// This value is set at build time using ldflags.
+var Version = "dev"


### PR DESCRIPTION
Currently `pulumi plugin` machinery does not quite work, we suspect this has to do with release automation and making binaries for the correct platforms. Copying automation from pulumi/pulumi-tool-cdk-importer where the automation works.