### PR TITLE
ci: reduce test parallelism to reduce flakes and stabilize CI

### DIFF
--- a/test/translate_test.go
+++ b/test/translate_test.go
@@ -294,4 +294,6 @@ func isolatePulumiHome(t *testing.T) {
 		os.RemoveAll(pulumiHome)
 	})
 	t.Setenv("PULUMI_HOME", pulumiHome)
+
+	_ = runCommand(t, pulumiHome, "pulumi", "login", "--local")
 }


### PR DESCRIPTION
CI becoming unstable because parallel tests collide in a race condition over installing templates or providers with `pulumi` CLI. Try isolating PULUMI_HOME for these tests.