### PR TITLE
Remove custom provider input hints

### DIFF
--- a/pkg/pulumi_providers.go
+++ b/pkg/pulumi_providers.go
@@ -93,26 +93,5 @@ func GetPulumiProvidersForTerraformState(tfState *tfjson.State) (map[providermap
 
 func GetProviderInputs(providerName string) (resource.PropertyMap, error) {
 	// TODO[pulumi/pulumi-service#35411]: produce correct provider inputs or fail gracefully with instructions
-	switch providerName {
-	case "aws":
-		return resource.PropertyMap{
-			"region":                    resource.NewProperty("us-east-1"),
-			"skipCredentialsValidation": resource.NewProperty(false),
-			"skipRegionValidation":      resource.NewProperty(true),
-			"version":                   resource.NewProperty("7.12.0"),
-		}, nil
-	case "archive":
-		return resource.PropertyMap{
-			"version": resource.NewProperty("0.3.5"),
-		}, nil
-	case "random":
-		return resource.PropertyMap{
-			"version": resource.NewProperty("4.18.1"),
-		}, nil
-	case "tls":
-		return resource.PropertyMap{
-			"version": resource.NewProperty("5.2.3"),
-		}, nil
-	}
-	return nil, fmt.Errorf("unsupported provider: %s", providerName)
+	return resource.PropertyMap{}, nil
 }


### PR DESCRIPTION
Originally code had some provider input hints so that generating a full Pulumi stack state would have some information to write in the Provider resource states. This is now removed. Producing no inputs is less misleading than assuming AWS provider is in us-east-1 for example, and this also gets rid of failures in the tool when unexpected providers are encountered.

If this tool is driven from an LLM it should be able to compensate by doing pulumi config set aws:region us-west-2 or similar.

This is a version of the https://github.com/pulumi/pulumi-tool-terraform-migrate/pull/67 PR that was not based on main properly, but got approved.