### PR TITLE
fix URN clash for module resources

### DIFF
--- a/pkg/testdata/tofu_state_nested_modules.json
+++ b/pkg/testdata/tofu_state_nested_modules.json
@@ -1,0 +1,420 @@
+{
+    "format_version": "1.0",
+    "terraform_version": "1.12.1",
+    "values": {
+        "root_module": {
+            "child_modules": [
+                {
+                    "resources": [
+                        {
+                            "address": "module.s3_bucket.aws_s3_bucket.this",
+                            "mode": "managed",
+                            "type": "aws_s3_bucket",
+                            "name": "this",
+                            "provider_name": "registry.terraform.io/hashicorp/aws",
+                            "schema_version": 0,
+                            "values": {
+                                "acceleration_status": "",
+                                "acl": null,
+                                "arn": "arn:aws:s3:::my-simple-bucket-example-123-1",
+                                "bucket": "my-simple-bucket-example-123-1",
+                                "bucket_domain_name": "my-simple-bucket-example-123-1.s3.amazonaws.com",
+                                "bucket_prefix": "",
+                                "bucket_regional_domain_name": "my-simple-bucket-example-123-1.s3.us-east-1.amazonaws.com",
+                                "cors_rule": [],
+                                "force_destroy": false,
+                                "grant": [
+                                    {
+                                        "id": "e07865a5679c7977370948f1f1e51c21b12d8cfdd396a7e3172275d9164e01b8",
+                                        "permissions": [
+                                            "FULL_CONTROL"
+                                        ],
+                                        "type": "CanonicalUser",
+                                        "uri": ""
+                                    }
+                                ],
+                                "hosted_zone_id": "Z3AQBSTGFYJSTF",
+                                "id": "my-simple-bucket-example-123-1",
+                                "lifecycle_rule": [],
+                                "logging": [],
+                                "object_lock_configuration": [],
+                                "object_lock_enabled": false,
+                                "policy": "",
+                                "region": "us-east-1",
+                                "replication_configuration": [],
+                                "request_payer": "BucketOwner",
+                                "server_side_encryption_configuration": [
+                                    {
+                                        "rule": [
+                                            {
+                                                "apply_server_side_encryption_by_default": [
+                                                    {
+                                                        "kms_master_key_id": "",
+                                                        "sse_algorithm": "AES256"
+                                                    }
+                                                ],
+                                                "bucket_key_enabled": false
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "tags": {},
+                                "tags_all": {},
+                                "timeouts": null,
+                                "versioning": [
+                                    {
+                                        "enabled": false,
+                                        "mfa_delete": false
+                                    }
+                                ],
+                                "website": [],
+                                "website_domain": null,
+                                "website_endpoint": null
+                            },
+                            "sensitive_values": {
+                                "cors_rule": [],
+                                "grant": [
+                                    {
+                                        "permissions": [
+                                            false
+                                        ]
+                                    }
+                                ],
+                                "lifecycle_rule": [],
+                                "logging": [],
+                                "object_lock_configuration": [],
+                                "replication_configuration": [],
+                                "server_side_encryption_configuration": [
+                                    {
+                                        "rule": [
+                                            {
+                                                "apply_server_side_encryption_by_default": [
+                                                    {}
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "tags": {},
+                                "tags_all": {},
+                                "versioning": [
+                                    {}
+                                ],
+                                "website": []
+                            }
+                        }
+                    ],
+                    "address": "module.s3_bucket",
+                    "child_modules": [
+                        {
+                            "resources": [
+                                {
+                                    "address": "module.s3_bucket.module.tags.aws_s3_bucket.this",
+                                    "mode": "managed",
+                                    "type": "aws_s3_bucket",
+                                    "name": "this",
+                                    "provider_name": "registry.terraform.io/hashicorp/aws",
+                                    "schema_version": 0,
+                                    "values": {
+                                        "acceleration_status": "",
+                                        "acl": null,
+                                        "arn": "arn:aws:s3:::my-simple-bucket-example-123-1-dev",
+                                        "bucket": "my-simple-bucket-example-123-1-dev",
+                                        "bucket_domain_name": "my-simple-bucket-example-123-1-dev.s3.amazonaws.com",
+                                        "bucket_prefix": "",
+                                        "bucket_regional_domain_name": "my-simple-bucket-example-123-1-dev.s3.us-east-1.amazonaws.com",
+                                        "cors_rule": [],
+                                        "force_destroy": false,
+                                        "grant": [
+                                            {
+                                                "id": "e07865a5679c7977370948f1f1e51c21b12d8cfdd396a7e3172275d9164e01b8",
+                                                "permissions": [
+                                                    "FULL_CONTROL"
+                                                ],
+                                                "type": "CanonicalUser",
+                                                "uri": ""
+                                            }
+                                        ],
+                                        "hosted_zone_id": "Z3AQBSTGFYJSTF",
+                                        "id": "my-simple-bucket-example-123-1-dev",
+                                        "lifecycle_rule": [],
+                                        "logging": [],
+                                        "object_lock_configuration": [],
+                                        "object_lock_enabled": false,
+                                        "policy": "",
+                                        "region": "us-east-1",
+                                        "replication_configuration": [],
+                                        "request_payer": "BucketOwner",
+                                        "server_side_encryption_configuration": [
+                                            {
+                                                "rule": [
+                                                    {
+                                                        "apply_server_side_encryption_by_default": [
+                                                            {
+                                                                "kms_master_key_id": "",
+                                                                "sse_algorithm": "AES256"
+                                                            }
+                                                        ],
+                                                        "bucket_key_enabled": false
+                                                    }
+                                                ]
+                                            }
+                                        ],
+                                        "tags": null,
+                                        "tags_all": {},
+                                        "timeouts": null,
+                                        "versioning": [
+                                            {
+                                                "enabled": false,
+                                                "mfa_delete": false
+                                            }
+                                        ],
+                                        "website": [],
+                                        "website_domain": null,
+                                        "website_endpoint": null
+                                    },
+                                    "sensitive_values": {
+                                        "cors_rule": [],
+                                        "grant": [
+                                            {
+                                                "permissions": [
+                                                    false
+                                                ]
+                                            }
+                                        ],
+                                        "lifecycle_rule": [],
+                                        "logging": [],
+                                        "object_lock_configuration": [],
+                                        "replication_configuration": [],
+                                        "server_side_encryption_configuration": [
+                                            {
+                                                "rule": [
+                                                    {
+                                                        "apply_server_side_encryption_by_default": [
+                                                            {}
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ],
+                                        "tags_all": {},
+                                        "versioning": [
+                                            {}
+                                        ],
+                                        "website": []
+                                    }
+                                }
+                            ],
+                            "address": "module.s3_bucket.module.tags"
+                        }
+                    ]
+                },
+                {
+                    "resources": [
+                        {
+                            "address": "module.s3_bucket_2.aws_s3_bucket.this",
+                            "mode": "managed",
+                            "type": "aws_s3_bucket",
+                            "name": "this",
+                            "provider_name": "registry.terraform.io/hashicorp/aws",
+                            "schema_version": 0,
+                            "values": {
+                                "acceleration_status": "",
+                                "acl": null,
+                                "arn": "arn:aws:s3:::my-simple-bucket-example-123-2",
+                                "bucket": "my-simple-bucket-example-123-2",
+                                "bucket_domain_name": "my-simple-bucket-example-123-2.s3.amazonaws.com",
+                                "bucket_prefix": "",
+                                "bucket_regional_domain_name": "my-simple-bucket-example-123-2.s3.us-east-1.amazonaws.com",
+                                "cors_rule": [],
+                                "force_destroy": false,
+                                "grant": [
+                                    {
+                                        "id": "e07865a5679c7977370948f1f1e51c21b12d8cfdd396a7e3172275d9164e01b8",
+                                        "permissions": [
+                                            "FULL_CONTROL"
+                                        ],
+                                        "type": "CanonicalUser",
+                                        "uri": ""
+                                    }
+                                ],
+                                "hosted_zone_id": "Z3AQBSTGFYJSTF",
+                                "id": "my-simple-bucket-example-123-2",
+                                "lifecycle_rule": [],
+                                "logging": [],
+                                "object_lock_configuration": [],
+                                "object_lock_enabled": false,
+                                "policy": "",
+                                "region": "us-east-1",
+                                "replication_configuration": [],
+                                "request_payer": "BucketOwner",
+                                "server_side_encryption_configuration": [
+                                    {
+                                        "rule": [
+                                            {
+                                                "apply_server_side_encryption_by_default": [
+                                                    {
+                                                        "kms_master_key_id": "",
+                                                        "sse_algorithm": "AES256"
+                                                    }
+                                                ],
+                                                "bucket_key_enabled": false
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "tags": {},
+                                "tags_all": {},
+                                "timeouts": null,
+                                "versioning": [
+                                    {
+                                        "enabled": false,
+                                        "mfa_delete": false
+                                    }
+                                ],
+                                "website": [],
+                                "website_domain": null,
+                                "website_endpoint": null
+                            },
+                            "sensitive_values": {
+                                "cors_rule": [],
+                                "grant": [
+                                    {
+                                        "permissions": [
+                                            false
+                                        ]
+                                    }
+                                ],
+                                "lifecycle_rule": [],
+                                "logging": [],
+                                "object_lock_configuration": [],
+                                "replication_configuration": [],
+                                "server_side_encryption_configuration": [
+                                    {
+                                        "rule": [
+                                            {
+                                                "apply_server_side_encryption_by_default": [
+                                                    {}
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "tags": {},
+                                "tags_all": {},
+                                "versioning": [
+                                    {}
+                                ],
+                                "website": []
+                            }
+                        }
+                    ],
+                    "address": "module.s3_bucket_2",
+                    "child_modules": [
+                        {
+                            "resources": [
+                                {
+                                    "address": "module.s3_bucket_2.module.tags.aws_s3_bucket.this",
+                                    "mode": "managed",
+                                    "type": "aws_s3_bucket",
+                                    "name": "this",
+                                    "provider_name": "registry.terraform.io/hashicorp/aws",
+                                    "schema_version": 0,
+                                    "values": {
+                                        "acceleration_status": "",
+                                        "acl": null,
+                                        "arn": "arn:aws:s3:::my-simple-bucket-example-123-2-dev",
+                                        "bucket": "my-simple-bucket-example-123-2-dev",
+                                        "bucket_domain_name": "my-simple-bucket-example-123-2-dev.s3.amazonaws.com",
+                                        "bucket_prefix": "",
+                                        "bucket_regional_domain_name": "my-simple-bucket-example-123-2-dev.s3.us-east-1.amazonaws.com",
+                                        "cors_rule": [],
+                                        "force_destroy": false,
+                                        "grant": [
+                                            {
+                                                "id": "e07865a5679c7977370948f1f1e51c21b12d8cfdd396a7e3172275d9164e01b8",
+                                                "permissions": [
+                                                    "FULL_CONTROL"
+                                                ],
+                                                "type": "CanonicalUser",
+                                                "uri": ""
+                                            }
+                                        ],
+                                        "hosted_zone_id": "Z3AQBSTGFYJSTF",
+                                        "id": "my-simple-bucket-example-123-2-dev",
+                                        "lifecycle_rule": [],
+                                        "logging": [],
+                                        "object_lock_configuration": [],
+                                        "object_lock_enabled": false,
+                                        "policy": "",
+                                        "region": "us-east-1",
+                                        "replication_configuration": [],
+                                        "request_payer": "BucketOwner",
+                                        "server_side_encryption_configuration": [
+                                            {
+                                                "rule": [
+                                                    {
+                                                        "apply_server_side_encryption_by_default": [
+                                                            {
+                                                                "kms_master_key_id": "",
+                                                                "sse_algorithm": "AES256"
+                                                            }
+                                                        ],
+                                                        "bucket_key_enabled": false
+                                                    }
+                                                ]
+                                            }
+                                        ],
+                                        "tags": null,
+                                        "tags_all": {},
+                                        "timeouts": null,
+                                        "versioning": [
+                                            {
+                                                "enabled": false,
+                                                "mfa_delete": false
+                                            }
+                                        ],
+                                        "website": [],
+                                        "website_domain": null,
+                                        "website_endpoint": null
+                                    },
+                                    "sensitive_values": {
+                                        "cors_rule": [],
+                                        "grant": [
+                                            {
+                                                "permissions": [
+                                                    false
+                                                ]
+                                            }
+                                        ],
+                                        "lifecycle_rule": [],
+                                        "logging": [],
+                                        "object_lock_configuration": [],
+                                        "replication_configuration": [],
+                                        "server_side_encryption_configuration": [
+                                            {
+                                                "rule": [
+                                                    {
+                                                        "apply_server_side_encryption_by_default": [
+                                                            {}
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ],
+                                        "tags_all": {},
+                                        "versioning": [
+                                            {}
+                                        ],
+                                        "website": []
+                                    }
+                                }
+                            ],
+                            "address": "module.s3_bucket_2.module.tags"
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+}

--- a/pkg/testdata/tofu_state_two_buckets.json
+++ b/pkg/testdata/tofu_state_two_buckets.json
@@ -1,0 +1,213 @@
+{
+    "format_version": "1.0",
+    "terraform_version": "1.12.1",
+    "values": {
+        "root_module": {
+            "child_modules": [
+                {
+                    "resources": [
+                        {
+                            "address": "module.s3_bucket.aws_s3_bucket.this",
+                            "mode": "managed",
+                            "type": "aws_s3_bucket",
+                            "name": "this",
+                            "provider_name": "registry.terraform.io/hashicorp/aws",
+                            "schema_version": 0,
+                            "values": {
+                                "acceleration_status": "",
+                                "acl": null,
+                                "arn": "arn:aws:s3:::my-simple-bucket-example-123-1",
+                                "bucket": "my-simple-bucket-example-123-1",
+                                "bucket_domain_name": "my-simple-bucket-example-123-1.s3.amazonaws.com",
+                                "bucket_prefix": "",
+                                "bucket_regional_domain_name": "my-simple-bucket-example-123-1.s3.us-east-1.amazonaws.com",
+                                "cors_rule": [],
+                                "force_destroy": false,
+                                "grant": [
+                                    {
+                                        "id": "e07865a5679c7977370948f1f1e51c21b12d8cfdd396a7e3172275d9164e01b8",
+                                        "permissions": [
+                                            "FULL_CONTROL"
+                                        ],
+                                        "type": "CanonicalUser",
+                                        "uri": ""
+                                    }
+                                ],
+                                "hosted_zone_id": "Z3AQBSTGFYJSTF",
+                                "id": "my-simple-bucket-example-123-1",
+                                "lifecycle_rule": [],
+                                "logging": [],
+                                "object_lock_configuration": [],
+                                "object_lock_enabled": false,
+                                "policy": "",
+                                "region": "us-east-1",
+                                "replication_configuration": [],
+                                "request_payer": "BucketOwner",
+                                "server_side_encryption_configuration": [
+                                    {
+                                        "rule": [
+                                            {
+                                                "apply_server_side_encryption_by_default": [
+                                                    {
+                                                        "kms_master_key_id": "",
+                                                        "sse_algorithm": "AES256"
+                                                    }
+                                                ],
+                                                "bucket_key_enabled": false
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "tags": {},
+                                "tags_all": {},
+                                "timeouts": null,
+                                "versioning": [
+                                    {
+                                        "enabled": false,
+                                        "mfa_delete": false
+                                    }
+                                ],
+                                "website": [],
+                                "website_domain": null,
+                                "website_endpoint": null
+                            },
+                            "sensitive_values": {
+                                "cors_rule": [],
+                                "grant": [
+                                    {
+                                        "permissions": [
+                                            false
+                                        ]
+                                    }
+                                ],
+                                "lifecycle_rule": [],
+                                "logging": [],
+                                "object_lock_configuration": [],
+                                "replication_configuration": [],
+                                "server_side_encryption_configuration": [
+                                    {
+                                        "rule": [
+                                            {
+                                                "apply_server_side_encryption_by_default": [
+                                                    {}
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "tags": {},
+                                "tags_all": {},
+                                "versioning": [
+                                    {}
+                                ],
+                                "website": []
+                            }
+                        }
+                    ],
+                    "address": "module.s3_bucket"
+                },
+                {
+                    "resources": [
+                        {
+                            "address": "module.s3_bucket_2.aws_s3_bucket.this",
+                            "mode": "managed",
+                            "type": "aws_s3_bucket",
+                            "name": "this",
+                            "provider_name": "registry.terraform.io/hashicorp/aws",
+                            "schema_version": 0,
+                            "values": {
+                                "acceleration_status": "",
+                                "acl": null,
+                                "arn": "arn:aws:s3:::my-simple-bucket-example-123-2",
+                                "bucket": "my-simple-bucket-example-123-2",
+                                "bucket_domain_name": "my-simple-bucket-example-123-2.s3.amazonaws.com",
+                                "bucket_prefix": "",
+                                "bucket_regional_domain_name": "my-simple-bucket-example-123-2.s3.us-east-1.amazonaws.com",
+                                "cors_rule": [],
+                                "force_destroy": false,
+                                "grant": [
+                                    {
+                                        "id": "e07865a5679c7977370948f1f1e51c21b12d8cfdd396a7e3172275d9164e01b8",
+                                        "permissions": [
+                                            "FULL_CONTROL"
+                                        ],
+                                        "type": "CanonicalUser",
+                                        "uri": ""
+                                    }
+                                ],
+                                "hosted_zone_id": "Z3AQBSTGFYJSTF",
+                                "id": "my-simple-bucket-example-123-2",
+                                "lifecycle_rule": [],
+                                "logging": [],
+                                "object_lock_configuration": [],
+                                "object_lock_enabled": false,
+                                "policy": "",
+                                "region": "us-east-1",
+                                "replication_configuration": [],
+                                "request_payer": "BucketOwner",
+                                "server_side_encryption_configuration": [
+                                    {
+                                        "rule": [
+                                            {
+                                                "apply_server_side_encryption_by_default": [
+                                                    {
+                                                        "kms_master_key_id": "",
+                                                        "sse_algorithm": "AES256"
+                                                    }
+                                                ],
+                                                "bucket_key_enabled": false
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "tags": null,
+                                "tags_all": {},
+                                "timeouts": null,
+                                "versioning": [
+                                    {
+                                        "enabled": false,
+                                        "mfa_delete": false
+                                    }
+                                ],
+                                "website": [],
+                                "website_domain": null,
+                                "website_endpoint": null
+                            },
+                            "sensitive_values": {
+                                "cors_rule": [],
+                                "grant": [
+                                    {
+                                        "permissions": [
+                                            false
+                                        ]
+                                    }
+                                ],
+                                "lifecycle_rule": [],
+                                "logging": [],
+                                "object_lock_configuration": [],
+                                "replication_configuration": [],
+                                "server_side_encryption_configuration": [
+                                    {
+                                        "rule": [
+                                            {
+                                                "apply_server_side_encryption_by_default": [
+                                                    {}
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "tags_all": {},
+                                "versioning": [
+                                    {}
+                                ],
+                                "website": []
+                            }
+                        }
+                    ],
+                    "address": "module.s3_bucket_2"
+                }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
This fixes an issue where TF resources with the same name but in different modules would be converted with the same URNs on the pulumi side. Now we will use the full module path in order to generate the pulumi URN.

fixes https://github.com/pulumi/pulumi-service/issues/36837