### PR TITLE
Fix workaround for pu-random utf8 issue

### DIFF
--- a/test/translate_test.go
+++ b/test/translate_test.go
@@ -190,7 +190,7 @@ func TestTranslateBasicWithEdit(t *testing.T) {
 	upResult, err := stack.Up(ctx)
 
 	// TODO[pulumi/pulumi-random#1967] intermittent failures here.
-	if strings.Contains(upResult.StdErr+upResult.StdOut, "string field contains invalid UTF-8") {
+	if err != nil && strings.Contains(err.Error(), "string field contains invalid UTF-8") {
 		return
 	}
 


### PR DESCRIPTION
This adds a small fix to the workaround for https://github.com/pulumi/pulumi-random/issues/1967.