### PR TITLE
Respect provider versions

### DIFF
--- a/pkg/pulumi_providers_test.go
+++ b/pkg/pulumi_providers_test.go
@@ -68,12 +68,12 @@ func TestGetPulumiProvidersForTerraformState(t *testing.T) {
 
 	statePath := createTestStateTfstate(t, tmpDir)
 
-	terraformState, err := tofu.LoadTerraformState(ctx, tofu.LoadTerraformStateOptions{
+	tfState, err := tofu.LoadTerraformState(ctx, tofu.LoadTerraformStateOptions{
 		StateFilePath: statePath,
 	})
 	require.NoError(t, err)
 
-	pulumiProviders, err := GetPulumiProvidersForTerraformState(terraformState)
+	pulumiProviders, err := GetPulumiProvidersForTerraformState(tfState, nil)
 	require.NoError(t, err)
 
 	require.Len(t, pulumiProviders, 1)

--- a/pkg/state_adapter_test.go
+++ b/pkg/state_adapter_test.go
@@ -94,7 +94,8 @@ func translateStateFromJson(ctx context.Context, tfStateJson string, pulumiProgr
 	if err != nil {
 		return nil, err
 	}
-	return TranslateState(ctx, tfState, pulumiProgramDir)
+	// When loading from JSON, we don't have provider versions
+	return TranslateState(ctx, tfState, nil, pulumiProgramDir)
 }
 
 func Test_convertState_simple(t *testing.T) {
@@ -106,7 +107,7 @@ func Test_convertState_simple(t *testing.T) {
 	})
 	require.NoError(t, err, "failed to load Terraform state")
 
-	pulumiProviders, err := GetPulumiProvidersForTerraformState(tfState)
+	pulumiProviders, err := GetPulumiProvidersForTerraformState(tfState, nil)
 	require.NoError(t, err, "failed to get Pulumi providers")
 
 	pulumiState, errorMessages, err := convertState(tfState, pulumiProviders)
@@ -133,7 +134,7 @@ func Test_convertState_multi_provider(t *testing.T) {
 	})
 	require.NoError(t, err, "failed to load Terraform state")
 
-	pulumiProviders, err := GetPulumiProvidersForTerraformState(tfState)
+	pulumiProviders, err := GetPulumiProvidersForTerraformState(tfState, nil)
 	require.NoError(t, err, "failed to get Pulumi providers")
 
 	pulumiState, errorMessages, err := convertState(tfState, pulumiProviders)
@@ -188,7 +189,7 @@ func Test_convertState_corrupted_state(t *testing.T) {
 	})
 	require.NoError(t, err, "failed to load Terraform state")
 
-	pulumiProviders, err := GetPulumiProvidersForTerraformState(tfState)
+	pulumiProviders, err := GetPulumiProvidersForTerraformState(tfState, nil)
 	require.NoError(t, err, "failed to get Pulumi providers")
 
 	_, errorMessages, err := convertState(tfState, pulumiProviders)

--- a/pkg/tofu/loader_test.go
+++ b/pkg/tofu/loader_test.go
@@ -65,7 +65,7 @@ func Test_LoadTerraformState(t *testing.T) {
 			opts: LoadTerraformStateOptions{
 				StateFilePath: "testdata/tf-project-with-lockfile/terraform.tfstate",
 			},
-			expectResources:          1,
+			expectResources:         1,
 			verifyLockfilePreserved: true,
 		},
 	}
@@ -102,6 +102,26 @@ func Test_LoadTerraformState(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_GetProviderVersions(t *testing.T) {
+	skipIfTofuNotAvailable(t)
+
+	ctx := context.Background()
+	projectDir := "testdata/tf-project-with-lockfile"
+
+	versionOutput, err := GetProviderVersions(ctx, projectDir)
+	require.NoError(t, err, "GetProviderVersions should not fail")
+
+	require.NotNil(t, versionOutput.ProviderSelections, "ProviderSelections should not be nil")
+	require.Equal(t, 1, len(versionOutput.ProviderSelections), "Expected 1 provider")
+
+	version, exists := versionOutput.ProviderSelections["registry.terraform.io/hashicorp/random"]
+	require.True(t, exists, "Expected registry.terraform.io/hashicorp/random to exist in ProviderSelections")
+	require.Equal(t, "3.7.2", version, "Expected provider version to match lock file")
+
+	require.NotEmpty(t, versionOutput.TerraformVersion, "TerraformVersion should be populated")
+	require.NotEmpty(t, versionOutput.Platform, "Platform should be populated")
 }
 
 // skipIfTofuNotAvailable skips the test if tofu is not in PATH


### PR DESCRIPTION
Propagate Terraform provider versions to the matching Pulumi provider picker. 

To figure out what the resolved Terraform provider versions are, this calls `tofu version -json`. Calling this after `init` ensures the versions are there. They will be either resolved right then or else if the user starts from a solution with a Terraform lock file, the locked versions will be respected and propagated.

Fixes https://github.com/pulumi/pulumi-service/issues/36839

It appears we just missed this in the initial version. The intention was always to respect the versions we find.