### PR TITLE
Fix panic with unknown providers

### DIFF
--- a/pkg/pulumi_providers.go
+++ b/pkg/pulumi_providers.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"maps"
+	"os"
 	"slices"
 
 	tfjson "github.com/hashicorp/terraform-json"
@@ -26,7 +27,6 @@ import (
 	"github.com/pulumi/pulumi-tool-terraform-migrate/pkg/providermap"
 	"github.com/pulumi/pulumi-tool-terraform-migrate/pkg/tofu"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
 func getTerraformProvidersForTerraformState(tfState *tfjson.State) ([]providermap.TerraformProviderName, error) {
@@ -64,7 +64,10 @@ func pulumiProvidersForTerraformProviders(
 		})
 
 		// TODO[pulumi/pulumi-service#35437]: make this work for Any TF
-		contract.Assertf(pulumiProvider.BridgedPulumiProvider != nil, "no bridged pulumi provider found for %s", providerName)
+		if pulumiProvider.BridgedPulumiProvider == nil {
+			fmt.Fprintf(os.Stderr, "Warning: no bridged Pulumi provider found for %s, resources using this provider will be skipped\n", providerName)
+			continue
+		}
 
 		result, err := bridgedproviders.EnsureProviderInstalled(context.Background(), bridgedproviders.InstallProviderOptions{
 			Name:    pulumiProvider.BridgedPulumiProvider.Identifier,

--- a/pkg/testdata/unknown_provider_state.json
+++ b/pkg/testdata/unknown_provider_state.json
@@ -1,0 +1,48 @@
+{
+  "format_version": "1.0",
+  "terraform_version": "1.10.6",
+  "values": {
+    "root_module": {
+      "resources": [
+        {
+          "address": "unknown_resource.example",
+          "mode": "managed",
+          "type": "unknown_resource",
+          "name": "example",
+          "provider_name": "registry.opentofu.org/hashicorp/unknown",
+          "schema_version": 0,
+          "values": {
+            "id": "12345",
+            "triggers": null
+          },
+          "sensitive_values": {}
+        },
+        {
+          "address": "random_string.example",
+          "mode": "managed",
+          "type": "random_string",
+          "name": "example",
+          "provider_name": "registry.opentofu.org/hashicorp/random",
+          "schema_version": 2,
+          "values": {
+            "id": "B*pc@KN!P5*2Cu<O",
+            "keepers": null,
+            "length": 16,
+            "lower": true,
+            "min_lower": 0,
+            "min_numeric": 0,
+            "min_special": 0,
+            "min_upper": 0,
+            "number": true,
+            "numeric": true,
+            "override_special": null,
+            "result": "B*pc@KN!P5*2Cu<O",
+            "special": true,
+            "upper": true
+          },
+          "sensitive_values": {}
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
We shouldn't panic when an unknown provider is encountered. Instead we will skip the resource and warn users about it.

fixes https://github.com/pulumi/pulumi-tool-terraform-migrate/issues/84