### PR TITLE
feat/mc-02-component-tree

### DIFF
--- a/pkg/module_tree.go
+++ b/pkg/module_tree.go
@@ -17,6 +17,7 @@ package pkg
 import (
 	"fmt"
 	"regexp"
+	"sort"
 	"strings"
 	"unicode"
 )
@@ -99,4 +100,219 @@ func parseModuleSegments(address string) []moduleSegment {
 	}
 
 	return segments
+}
+
+// componentNode represents a component resource in the tree.
+type componentNode struct {
+	name         string           // module name (e.g., "vpc")
+	key          string           // index/key if present
+	resourceName string           // Pulumi resource name (e.g., "vpc" or "vpc-0")
+	typeToken    string           // Pulumi type token
+	modulePath   string           // full TF module path (e.g., "module.vpc.module.subnets")
+	children     []*componentNode // child components
+}
+
+// buildComponentTree constructs a tree of component nodes from TF resource addresses.
+// typeOverrides maps TF module paths (e.g., "module.vpc") to Pulumi type tokens.
+// Returns error on name/type collisions. Results sorted alphabetically at each level.
+func buildComponentTree(resourceAddresses []string, typeOverrides map[string]string) ([]*componentNode, error) {
+	type moduleInfo struct {
+		segments []moduleSegment
+		path     string
+	}
+
+	seen := map[string]bool{}
+	var allPaths []moduleInfo
+
+	for _, addr := range resourceAddresses {
+		segs := parseModuleSegments(addr)
+		if segs == nil {
+			continue
+		}
+		// Register all prefix paths for nesting
+		for depth := 1; depth <= len(segs); depth++ {
+			prefix := make([]moduleSegment, depth)
+			copy(prefix, segs[:depth])
+			path := buildModulePath(prefix)
+			if !seen[path] {
+				seen[path] = true
+				allPaths = append(allPaths, moduleInfo{segments: prefix, path: path})
+			}
+		}
+	}
+
+	// Sort by depth (shorter paths first), then alphabetically
+	sort.Slice(allPaths, func(i, j int) bool {
+		if len(allPaths[i].segments) != len(allPaths[j].segments) {
+			return len(allPaths[i].segments) < len(allPaths[j].segments)
+		}
+		return allPaths[i].path < allPaths[j].path
+	})
+
+	rootNodes := map[string]*componentNode{}
+	allNodes := map[string]*componentNode{}
+
+	for _, info := range allPaths {
+		lastSeg := info.segments[len(info.segments)-1]
+		resName := lastSeg.name
+		if lastSeg.key != "" {
+			resName = sanitizeModuleInstanceName(lastSeg.name, lastSeg.key)
+		}
+
+		// Determine type token: check override using base path (without index)
+		basePath := buildModuleBasePath(info.segments)
+		typeToken := deriveComponentTypeToken(lastSeg.name)
+		if override, ok := typeOverrides[basePath]; ok {
+			typeToken = override
+		}
+
+		node := &componentNode{
+			name:         lastSeg.name,
+			key:          lastSeg.key,
+			resourceName: resName,
+			typeToken:    typeToken,
+			modulePath:   info.path,
+		}
+		allNodes[info.path] = node
+
+		if len(info.segments) == 1 {
+			rootNodes[info.path] = node
+		} else {
+			parentPath := buildModulePath(info.segments[:len(info.segments)-1])
+			if parent, ok := allNodes[parentPath]; ok {
+				parent.children = append(parent.children, node)
+			}
+		}
+	}
+
+	// Validate: check for collision on (resourceName, parentPath)
+	type nameKey struct{ name, parent string }
+	names := map[nameKey]string{} // key -> original module path
+	for _, info := range allPaths {
+		node := allNodes[info.path]
+		parentPath := ""
+		if len(info.segments) > 1 {
+			parentPath = buildModulePath(info.segments[:len(info.segments)-1])
+		}
+		key := nameKey{node.resourceName, parentPath}
+		if existing, ok := names[key]; ok && existing != info.path {
+			return nil, fmt.Errorf("component name collision: %q and %q both produce name %q under the same parent",
+				existing, info.path, node.resourceName)
+		}
+		names[key] = info.path
+	}
+
+	// Collect and sort root nodes alphabetically
+	var result []*componentNode
+	for _, node := range rootNodes {
+		result = append(result, node)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].resourceName < result[j].resourceName
+	})
+
+	// Sort children at each level
+	var sortChildren func(nodes []*componentNode)
+	sortChildren = func(nodes []*componentNode) {
+		for _, n := range nodes {
+			if len(n.children) > 0 {
+				sort.Slice(n.children, func(i, j int) bool {
+					return n.children[i].resourceName < n.children[j].resourceName
+				})
+				sortChildren(n.children)
+			}
+		}
+	}
+	sortChildren(result)
+
+	return result, nil
+}
+
+// buildModulePath constructs a full module path string from segments.
+// Example: [{name:"vpc"}, {name:"subnets"}] -> "module.vpc.module.subnets"
+func buildModulePath(segments []moduleSegment) string {
+	var parts []string
+	for _, seg := range segments {
+		if seg.key != "" {
+			parts = append(parts, fmt.Sprintf("module.%s[%s]", seg.name, formatKey(seg.key)))
+		} else {
+			parts = append(parts, "module."+seg.name)
+		}
+	}
+	return strings.Join(parts, ".")
+}
+
+// buildModuleBasePath constructs a module path without indices/keys for type override matching.
+// Example: [{name:"vpc", key:"0"}] -> "module.vpc"
+func buildModuleBasePath(segments []moduleSegment) string {
+	var parts []string
+	for _, seg := range segments {
+		parts = append(parts, "module."+seg.name)
+	}
+	return strings.Join(parts, ".")
+}
+
+func formatKey(key string) string {
+	if _, err := fmt.Sscanf(key, "%d", new(int)); err == nil {
+		return key
+	}
+	return `"` + key + `"`
+}
+
+// toComponents converts the component tree into a flat, depth-first ordered list of PulumiResources.
+// parentTypeChain is the $-delimited type chain of the parent (empty for top-level).
+func toComponents(nodes []*componentNode, parentTypeChain string) []PulumiResource {
+	var result []PulumiResource
+	for _, node := range nodes {
+		comp := PulumiResource{
+			PulumiResourceID: PulumiResourceID{
+				Name: node.resourceName,
+				Type: node.typeToken,
+			},
+			Parent: parentTypeChain,
+		}
+		result = append(result, comp)
+
+		childParentChain := node.typeToken
+		if parentTypeChain != "" {
+			childParentChain = parentTypeChain + "$" + node.typeToken
+		}
+
+		if len(node.children) > 0 {
+			result = append(result, toComponents(node.children, childParentChain)...)
+		}
+	}
+	return result
+}
+
+// componentParentForResource returns the parent type chain for a resource at the given module path.
+func componentParentForResource(nodes []*componentNode, segments []moduleSegment) string {
+	if len(segments) == 0 {
+		return ""
+	}
+
+	current := nodes
+	var typeChain string
+	for _, seg := range segments {
+		targetName := seg.name
+		if seg.key != "" {
+			targetName = sanitizeModuleInstanceName(seg.name, seg.key)
+		}
+		found := false
+		for _, node := range current {
+			if node.resourceName == targetName {
+				if typeChain != "" {
+					typeChain += "$"
+				}
+				typeChain += node.typeToken
+				current = node.children
+				found = true
+				break
+			}
+		}
+		if !found {
+			return ""
+		}
+	}
+	return typeChain
 }

--- a/pkg/module_tree_test.go
+++ b/pkg/module_tree_test.go
@@ -60,6 +60,142 @@ func TestSanitizeModuleInstanceName(t *testing.T) {
 	}
 }
 
+func TestBuildComponentTree_SingleModule(t *testing.T) {
+	tree, err := buildComponentTree(
+		[]string{"module.vpc.aws_subnet.this", "module.vpc.aws_route_table.rt"},
+		nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, tree, 1)
+	require.Equal(t, "vpc", tree[0].name)
+	require.Equal(t, "terraform:module/vpc:Vpc", tree[0].typeToken)
+	require.Nil(t, tree[0].children)
+}
+
+func TestBuildComponentTree_NestedModules(t *testing.T) {
+	tree, err := buildComponentTree(
+		[]string{
+			"module.vpc.module.subnets.aws_subnet.this",
+			"module.vpc.aws_vpc.main",
+		},
+		nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, tree, 1)
+	require.Equal(t, "vpc", tree[0].name)
+	require.Len(t, tree[0].children, 1)
+	require.Equal(t, "subnets", tree[0].children[0].name)
+}
+
+func TestBuildComponentTree_WithTypeOverride(t *testing.T) {
+	tree, err := buildComponentTree(
+		[]string{"module.vpc.aws_subnet.this"},
+		map[string]string{"module.vpc": "myproject:index:VpcComponent"},
+	)
+	require.NoError(t, err)
+	require.Equal(t, "myproject:index:VpcComponent", tree[0].typeToken)
+}
+
+func TestBuildComponentTree_IndexedModules(t *testing.T) {
+	tree, err := buildComponentTree(
+		[]string{
+			"module.vpc[0].aws_subnet.this",
+			"module.vpc[1].aws_subnet.this",
+		},
+		nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, tree, 2)
+	require.Equal(t, "vpc-0", tree[0].resourceName)
+	require.Equal(t, "vpc-1", tree[1].resourceName)
+	require.Equal(t, tree[0].typeToken, tree[1].typeToken)
+}
+
+func TestBuildComponentTree_SiblingsSortedAlphabetically(t *testing.T) {
+	tree, err := buildComponentTree(
+		[]string{
+			"module.zebra.aws_s3_bucket.this",
+			"module.alpha.aws_s3_bucket.this",
+		},
+		nil,
+	)
+	require.NoError(t, err)
+	require.Equal(t, "alpha", tree[0].resourceName)
+	require.Equal(t, "zebra", tree[1].resourceName)
+}
+
+func TestBuildComponentTree_Empty(t *testing.T) {
+	tree, err := buildComponentTree([]string{}, nil)
+	require.NoError(t, err)
+	require.Len(t, tree, 0)
+}
+
+func TestBuildComponentTree_RootResourcesIgnored(t *testing.T) {
+	tree, err := buildComponentTree(
+		[]string{"aws_s3_bucket.this"},
+		nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, tree, 0)
+}
+
+func TestBuildComponentTree_SanitizationCollision(t *testing.T) {
+	_, err := buildComponentTree(
+		[]string{
+			`module.vpc["us-east-1"].aws_subnet.this`,
+			`module.vpc["us_east_1"].aws_subnet.that`,
+		},
+		nil,
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "collision")
+}
+
+func TestToComponents_DepthFirst(t *testing.T) {
+	tree, err := buildComponentTree(
+		[]string{
+			"module.vpc.module.subnets.aws_subnet.this",
+			"module.vpc.aws_vpc.main",
+		},
+		nil,
+	)
+	require.NoError(t, err)
+
+	components := toComponents(tree, "")
+	require.Len(t, components, 2)
+	// vpc first (parent), then subnets (child)
+	require.Equal(t, "vpc", components[0].Name)
+	require.Equal(t, "", components[0].Parent) // top-level
+	require.Equal(t, "subnets", components[1].Name)
+	require.Equal(t, "terraform:module/vpc:Vpc", components[1].Parent) // child of vpc
+}
+
+func TestComponentParentForResource(t *testing.T) {
+	tree, err := buildComponentTree(
+		[]string{
+			"module.vpc.module.subnets.aws_subnet.this",
+			"module.vpc.aws_vpc.main",
+		},
+		nil,
+	)
+	require.NoError(t, err)
+
+	// Resource in nested module
+	segments := parseModuleSegments("module.vpc.module.subnets.aws_subnet.this")
+	parent := componentParentForResource(tree, segments)
+	require.Equal(t, "terraform:module/vpc:Vpc$terraform:module/subnets:Subnets", parent)
+
+	// Resource in top-level module
+	segments = parseModuleSegments("module.vpc.aws_vpc.main")
+	parent = componentParentForResource(tree, segments)
+	require.Equal(t, "terraform:module/vpc:Vpc", parent)
+
+	// Root resource (no module)
+	segments = parseModuleSegments("aws_s3_bucket.this")
+	parent = componentParentForResource(tree, segments)
+	require.Equal(t, "", parent)
+}
+
 func TestParseModuleSegments(t *testing.T) {
 	tests := []struct {
 		address  string

--- a/pkg/pulumi_state.go
+++ b/pkg/pulumi_state.go
@@ -53,8 +53,13 @@ type PulumiResource struct {
 
 	// For resources this identifies the associated provider.
 	//
-	// For provider resources this nil.
+	// For provider resources and components this is nil.
 	Provider *PulumiResourceID
+
+	// Parent type chain for URN encoding (e.g., "terraform:module/vpc:Vpc" or
+	// "terraform:module/vpc:Vpc$terraform:module/subnets:Subnets").
+	// Empty string means parent is Stack.
+	Parent string
 }
 
 type PulumiState struct {


### PR DESCRIPTION
**Design & Plan:** [`feat/module-to-component-design`](https://github.com/pulumi/pulumi-tool-terraform-migrate/tree/feat/module-to-component-design) ([spec](https://github.com/pulumi/pulumi-tool-terraform-migrate/blob/feat/module-to-component-design/docs/superpowers/specs/2026-03-31-module-to-component-design.md) · [plan](https://github.com/pulumi/pulumi-tool-terraform-migrate/blob/feat/module-to-component-design/docs/superpowers/plans/2026-03-31-module-to-component.md))


Adds componentNode struct, buildComponentTree (with sanitization collision
detection), toComponents (depth-first flattening), and
componentParentForResource. Also adds Parent field to PulumiResource.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>