### PR TITLE
feat/mc-03-pulumi-state

### DIFF
--- a/pkg/pulumi_state.go
+++ b/pkg/pulumi_state.go
@@ -34,6 +34,15 @@ func makeUrn(stackName, projectName, typeName, resourceName string) resource.URN
 	return resource.URN(fmt.Sprintf("urn:pulumi:%s::%s::%s::%s", stackName, projectName, typeName, resourceName))
 }
 
+// makeUrnWithParent creates a Pulumi URN with a parent type chain encoded via $ delimiters.
+func makeUrnWithParent(stackName, projectName, parentTypeChain, typeName, resourceName string) resource.URN {
+	fullType := typeName
+	if parentTypeChain != "" {
+		fullType = parentTypeChain + "$" + typeName
+	}
+	return resource.URN(fmt.Sprintf("urn:pulumi:%s::%s::%s::%s", stackName, projectName, fullType, resourceName))
+}
+
 // Identifier within a stack.
 type PulumiResourceID struct {
 	ID   string
@@ -63,8 +72,9 @@ type PulumiResource struct {
 }
 
 type PulumiState struct {
-	Providers []PulumiResource
-	Resources []PulumiResource
+	Providers  []PulumiResource
+	Components []PulumiResource
+	Resources  []PulumiResource
 }
 
 func (st PulumiState) FindProvider(identity PulumiResourceID) (PulumiResource, error) {
@@ -156,6 +166,48 @@ func InsertResourcesIntoDeployment(state *PulumiState, stackName, projectName st
 		deployment.Resources = append(deployment.Resources, provider)
 	}
 
+	// Insert component resources (after providers, before custom resources).
+	// Components are in depth-first order, so parents are always inserted before children.
+	componentURNs := map[string]resource.URN{} // type chain -> URN
+
+	for _, comp := range state.Components {
+		urn := makeUrnWithParent(stackName, projectName, comp.Parent, comp.Type, comp.Name)
+
+		parentURN := stackURN
+		if comp.Parent != "" {
+			if parentComponentURN, ok := componentURNs[comp.Parent]; ok {
+				parentURN = parentComponentURN
+			}
+		}
+
+		// Register this component's full type chain for child lookups
+		fullTypeChain := comp.Type
+		if comp.Parent != "" {
+			fullTypeChain = comp.Parent + "$" + comp.Type
+		}
+		componentURNs[fullTypeChain] = urn
+
+		inputs := comp.Inputs
+		if inputs == nil {
+			inputs = resource.PropertyMap{}
+		}
+		outputs := comp.Outputs
+		if outputs == nil {
+			outputs = resource.PropertyMap{}
+		}
+
+		deployment.Resources = append(deployment.Resources, apitype.ResourceV3{
+			URN:      urn,
+			Custom:   false,
+			Type:     tokens.Type(comp.Type),
+			Inputs:   inputs.Mappable(),
+			Outputs:  outputs.Mappable(),
+			Parent:   parentURN,
+			Created:  &now,
+			Modified: &now,
+		})
+	}
+
 	for _, res := range state.Resources {
 		contract.Assertf(res.Provider != nil, "Expected a provider association for a custom resource")
 
@@ -167,14 +219,23 @@ func InsertResourcesIntoDeployment(state *PulumiState, stackName, projectName st
 		providerURN := makeUrn(stackName, projectName, providerRecord.Type, providerRecord.Name)
 		providerLink := fmt.Sprintf("%s::%s", providerURN, providerRecord.ID)
 
+		urn := makeUrnWithParent(stackName, projectName, res.Parent, res.Type, res.Name)
+
+		parentURN := stackURN
+		if res.Parent != "" {
+			if parentComponentURN, ok := componentURNs[res.Parent]; ok {
+				parentURN = parentComponentURN
+			}
+		}
+
 		deployment.Resources = append(deployment.Resources, apitype.ResourceV3{
-			URN:      makeUrn(stackName, projectName, res.Type, res.Name),
+			URN:      urn,
 			Custom:   true,
 			ID:       resource.ID(res.ID),
 			Type:     tokens.Type(res.Type),
 			Inputs:   res.Inputs.Mappable(),
 			Outputs:  res.Outputs.Mappable(),
-			Parent:   stackURN,
+			Parent:   parentURN,
 			Provider: providerLink,
 			Created:  &now,
 			Modified: &now,

--- a/pkg/pulumi_state_test.go
+++ b/pkg/pulumi_state_test.go
@@ -17,11 +17,13 @@ package pkg
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/hexops/autogold/v2"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/stretchr/testify/require"
 )
 
@@ -221,6 +223,130 @@ func TestInsertResourcesIntoDeployment_EmptyProjectName(t *testing.T) {
 	_, err := InsertResourcesIntoDeployment(&PulumiState{}, "dev", "")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "projectName")
+}
+
+func TestInsertResourcesIntoDeployment_WithComponents(t *testing.T) {
+	stackName := "dev"
+	projectName := "testproject"
+
+	providerID := PulumiResourceID{ID: "provider-uuid", Name: "default_6_0_0", Type: "pulumi:providers:aws"}
+	state := &PulumiState{
+		Providers: []PulumiResource{
+			{PulumiResourceID: providerID, Inputs: resource.PropertyMap{}, Outputs: resource.PropertyMap{}},
+		},
+		Components: []PulumiResource{
+			{
+				PulumiResourceID: PulumiResourceID{Name: "vpc", Type: "terraform:module/vpc:Vpc"},
+				Parent:           "",
+			},
+		},
+		Resources: []PulumiResource{
+			{
+				PulumiResourceID: PulumiResourceID{ID: "subnet-123", Name: "this", Type: "aws:ec2/subnet:Subnet"},
+				Provider:         &providerID,
+				Parent:           "terraform:module/vpc:Vpc",
+				Inputs:           resource.PropertyMap{},
+				Outputs:          resource.PropertyMap{},
+			},
+		},
+	}
+
+	result, err := InsertResourcesIntoDeployment(state, stackName, projectName)
+	require.NoError(t, err)
+
+	// Stack + provider + component + resource = 4
+	require.Len(t, result.Resources, 4)
+
+	// Verify ordering: Stack, provider, component, resource
+	require.Equal(t, tokens.Type("pulumi:pulumi:Stack"), result.Resources[0].Type)
+	require.True(t, result.Resources[1].Custom)  // provider
+	require.False(t, result.Resources[2].Custom) // component
+	require.True(t, result.Resources[3].Custom)  // resource
+
+	// Verify component resource
+	component := result.Resources[2]
+	require.False(t, component.Custom)
+	require.Equal(t, tokens.Type("terraform:module/vpc:Vpc"), component.Type)
+	require.Empty(t, component.ID)
+	require.Empty(t, component.Provider)
+
+	// Verify resource is parented to component
+	res := result.Resources[3]
+	require.Contains(t, string(res.Parent), "terraform:module/vpc:Vpc")
+}
+
+func TestInsertResourcesIntoDeployment_NestedComponents(t *testing.T) {
+	stackName := "dev"
+	projectName := "testproject"
+
+	providerID := PulumiResourceID{ID: "pid", Name: "default_1_0_0", Type: "pulumi:providers:aws"}
+	state := &PulumiState{
+		Providers: []PulumiResource{
+			{PulumiResourceID: providerID, Inputs: resource.PropertyMap{}, Outputs: resource.PropertyMap{}},
+		},
+		Components: []PulumiResource{
+			{
+				PulumiResourceID: PulumiResourceID{Name: "vpc", Type: "terraform:module/vpc:Vpc"},
+				Parent:           "",
+			},
+			{
+				PulumiResourceID: PulumiResourceID{Name: "subnets", Type: "terraform:module/subnets:Subnets"},
+				Parent:           "terraform:module/vpc:Vpc",
+			},
+		},
+		Resources: []PulumiResource{
+			{
+				PulumiResourceID: PulumiResourceID{ID: "subnet-1", Name: "this", Type: "aws:ec2/subnet:Subnet"},
+				Provider:         &providerID,
+				Parent:           "terraform:module/vpc:Vpc$terraform:module/subnets:Subnets",
+				Inputs:           resource.PropertyMap{},
+				Outputs:          resource.PropertyMap{},
+			},
+		},
+	}
+
+	result, err := InsertResourcesIntoDeployment(state, stackName, projectName)
+	require.NoError(t, err)
+	require.Len(t, result.Resources, 5) // Stack + provider + 2 components + resource
+
+	// subnets component should be parented to vpc component
+	subnets := result.Resources[3]
+	require.False(t, subnets.Custom)
+	require.Contains(t, string(subnets.Parent), "terraform:module/vpc:Vpc")
+
+	// resource should be parented to subnets component
+	res := result.Resources[4]
+	require.Contains(t, string(res.Parent), "terraform:module/subnets:Subnets")
+
+	// URN should encode parent type chain with $ delimiter
+	require.True(t, strings.Contains(string(res.URN), "terraform:module/vpc:Vpc$terraform:module/subnets:Subnets$aws:ec2/subnet:Subnet"))
+}
+
+func TestInsertResourcesIntoDeployment_NoComponents_BackwardCompat(t *testing.T) {
+	stackName := "dev"
+	projectName := "testproject"
+
+	providerID := PulumiResourceID{ID: "pid", Name: "default_1_0_0", Type: "pulumi:providers:random"}
+	state := &PulumiState{
+		Providers: []PulumiResource{
+			{PulumiResourceID: providerID, Inputs: resource.PropertyMap{}, Outputs: resource.PropertyMap{}},
+		},
+		Components: nil,
+		Resources: []PulumiResource{
+			{
+				PulumiResourceID: PulumiResourceID{ID: "abc", Name: "test", Type: "random:index/randomPet:RandomPet"},
+				Provider:         &providerID,
+				Inputs:           resource.PropertyMap{},
+				Outputs:          resource.PropertyMap{},
+			},
+		},
+	}
+
+	result, err := InsertResourcesIntoDeployment(state, stackName, projectName)
+	require.NoError(t, err)
+	require.Len(t, result.Resources, 3) // Stack + provider + resource
+	// Resource parent should be Stack
+	require.Contains(t, string(result.Resources[2].Parent), "pulumi:pulumi:Stack")
 }
 
 func TestGetProjectName(t *testing.T) {


### PR DESCRIPTION
**Design & Plan:** [`feat/module-to-component-design`](https://github.com/pulumi/pulumi-tool-terraform-migrate/tree/feat/module-to-component-design) ([spec](https://github.com/pulumi/pulumi-tool-terraform-migrate/blob/feat/module-to-component-design/docs/superpowers/specs/2026-03-31-module-to-component-design.md) · [plan](https://github.com/pulumi/pulumi-tool-terraform-migrate/blob/feat/module-to-component-design/docs/superpowers/plans/2026-03-31-module-to-component.md))


Adds makeUrnWithParent for $-delimited parent type chains, Components
field on PulumiState, and component resource insertion in
InsertResourcesIntoDeployment (between providers and custom resources).
Uses componentURNs map for O(1) parent lookups.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>