### PR TITLE
feat/mc-04-pipeline-integration

### DIFF
--- a/cmd/stack.go
+++ b/cmd/stack.go
@@ -16,6 +16,8 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+	"strings"
 
 	"github.com/pulumi/pulumi-tool-terraform-migrate/pkg"
 	"github.com/spf13/cobra"
@@ -27,6 +29,8 @@ func newStackCmd() *cobra.Command {
 	var to string
 	var plugins string
 	var strict bool
+	var noModuleComponents bool
+	var moduleTypeMaps []string
 	var pulumiStack string
 	var pulumiProject string
 
@@ -70,7 +74,22 @@ See also:
   https://www.pulumi.com/docs/iac/cli/commands/pulumi_plugin_install/
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			err := pkg.TranslateAndWriteState(cmd.Context(), from, to, out, plugins, strict, pulumiStack, pulumiProject)
+			typeOverrides := map[string]string{}
+			for _, mapping := range moduleTypeMaps {
+				parts := strings.SplitN(mapping, "=", 2)
+				if len(parts) != 2 {
+					return fmt.Errorf("invalid --module-type-map format %q, expected module.name=type:token", mapping)
+				}
+				typeOverrides[parts[0]] = parts[1]
+			}
+
+			enableComponents := !noModuleComponents
+			if noModuleComponents && len(moduleTypeMaps) > 0 {
+				fmt.Fprintf(os.Stderr, "Warning: --module-type-map is ignored when --no-module-components is set\n")
+				typeOverrides = nil
+			}
+
+			err := pkg.TranslateAndWriteState(cmd.Context(), from, to, out, plugins, strict, enableComponents, typeOverrides, pulumiStack, pulumiProject)
 			if err != nil {
 				return fmt.Errorf("failed to convert and write Terraform state: %w", err)
 			}
@@ -83,6 +102,10 @@ See also:
 	cmd.Flags().StringVarP(&out, "out", "o", "", "Where to emit the translated Pulumi stack file")
 	cmd.Flags().StringVarP(&plugins, "plugins", "p", "", "Where to emit plugin requirements")
 	cmd.Flags().BoolVarP(&strict, "strict", "s", false, "Fail if any resources fail to be translated")
+	cmd.Flags().BoolVar(&noModuleComponents, "no-module-components", false,
+		"Disable creation of component resources for Terraform modules (flat mode)")
+	cmd.Flags().StringArrayVar(&moduleTypeMaps, "module-type-map", nil,
+		"Override component type token for a module (repeatable, format: module.name=pkg:mod:Type)")
 	cmd.Flags().StringVar(&pulumiStack, "pulumi-stack", "", "Override Pulumi stack name (skip auto-detection)")
 	cmd.Flags().StringVar(&pulumiProject, "pulumi-project", "", "Override Pulumi project name (skip auto-detection)")
 

--- a/pkg/state_adapter.go
+++ b/pkg/state_adapter.go
@@ -54,6 +54,8 @@ func TranslateAndWriteState(
 	outputFilePath string,
 	requiredProvidersOutputFilePath string,
 	strict bool,
+	enableComponents bool,
+	typeOverrides map[string]string,
 	stackNameOverride string,
 	projectNameOverride string,
 ) error {
@@ -94,7 +96,7 @@ func TranslateAndWriteState(
 		}
 	}
 
-	res, err := TranslateState(ctx, tfState, providerVersions.ProviderSelections, stackName, projectName)
+	res, err := TranslateState(ctx, tfState, providerVersions.ProviderSelections, stackName, projectName, enableComponents, typeOverrides)
 	if err != nil {
 		return err
 	}
@@ -142,13 +144,13 @@ type TranslateStateResult struct {
 	ErrorMessages     []ErroredResource
 }
 
-func TranslateState(ctx context.Context, tfState *tfjson.State, providerVersions map[string]string, stackName, projectName string) (*TranslateStateResult, error) {
+func TranslateState(ctx context.Context, tfState *tfjson.State, providerVersions map[string]string, stackName, projectName string, enableComponents bool, typeOverrides map[string]string) (*TranslateStateResult, error) {
 	pulumiProviders, err := GetPulumiProvidersForTerraformState(tfState, providerVersions)
 	if err != nil {
 		return nil, err
 	}
 
-	pulumiState, errorMessages, err := convertState(tfState, pulumiProviders)
+	pulumiState, errorMessages, err := convertState(tfState, pulumiProviders, enableComponents, typeOverrides)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert state: %w", err)
 	}
@@ -177,7 +179,7 @@ type ErroredResource struct {
 	ErrorMessage     string `json:"error_message"`
 }
 
-func convertState(tfState *tfjson.State, pulumiProviders map[providermap.TerraformProviderName]*ProviderWithMetadata) (*PulumiState, []ErroredResource, error) {
+func convertState(tfState *tfjson.State, pulumiProviders map[providermap.TerraformProviderName]*ProviderWithMetadata, enableComponents bool, typeOverrides map[string]string) (*PulumiState, []ErroredResource, error) {
 	pulumiState := &PulumiState{}
 
 	// TODO[pulumi/pulumi-service#35512]: This assumes one Pulumi provider per Terraform provider.
@@ -202,6 +204,25 @@ func convertState(tfState *tfjson.State, pulumiProviders map[providermap.Terrafo
 		}
 		pulumiState.Providers = append(pulumiState.Providers, providerResource)
 		providerTable[tfProviderName] = providerResource.PulumiResourceID
+	}
+
+	// Build component tree from module hierarchy if enabled
+	var componentTree []*componentNode
+	if enableComponents {
+		var resourceAddresses []string
+		tofu.VisitResources(tfState, func(r *tfjson.StateResource) error {
+			resourceAddresses = append(resourceAddresses, r.Address)
+			return nil
+		}, &tofu.VisitOptions{})
+
+		if len(resourceAddresses) > 0 {
+			var err error
+			componentTree, err = buildComponentTree(resourceAddresses, typeOverrides)
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to build component tree: %w", err)
+			}
+			pulumiState.Components = toComponents(componentTree, "")
+		}
 	}
 
 	errorMessages := []ErroredResource{}
@@ -230,6 +251,14 @@ func convertState(tfState *tfjson.State, pulumiProviders map[providermap.Terrafo
 			return nil
 		}
 		pulumiResource.Provider = &providerLink
+
+		// When components are enabled, use short name and set parent
+		if enableComponents {
+			pulumiResource.Name = PulumiNameFromTerraformAddress(resource.Address, resource.Type, true)
+			segments := parseModuleSegments(resource.Address)
+			pulumiResource.Parent = componentParentForResource(componentTree, segments)
+		}
+
 		pulumiState.Resources = append(pulumiState.Resources, pulumiResource)
 		return nil
 	}, &tofu.VisitOptions{})
@@ -287,7 +316,7 @@ func convertResourceStateExceptProviderLink(
 	return PulumiResource{
 		PulumiResourceID: PulumiResourceID{
 			ID:   props["id"].StringValue(),
-			Name: PulumiNameFromTerraformAddress(res.Address, res.Type),
+			Name: PulumiNameFromTerraformAddress(res.Address, res.Type, false),
 			Type: string(pulumiTypeToken),
 		},
 		Inputs:  inputs,
@@ -316,10 +345,21 @@ func formatDynamicProviderName(tfAddr string) string {
 //   - Submodule: module.<module_name>.<resource_type>.<name> e.g., "module.s3_bucket.aws_s3_bucket.this"
 //   - Nested: module.<mod1>.module.<mod2>.<resource_type>.<name>
 //
-// We extract the module path and resource name (excluding the type) and join them with underscores.
-func PulumiNameFromTerraformAddress(address, resourceType string) string {
+// When useShortName is true, only the resource name after the type is returned (module path is
+// expressed via the parent component chain instead). When false, module path is baked into the name.
+func PulumiNameFromTerraformAddress(address, resourceType string, useShortName bool) string {
 	parts := strings.Split(address, ".")
 
+	if useShortName {
+		// Return only the resource name part (after the type)
+		for i := 0; i < len(parts); i++ {
+			if parts[i] == resourceType {
+				return strings.Join(parts[i+1:], "_")
+			}
+		}
+	}
+
+	// Original behavior: include module path in name
 	var nameParts []string
 	for i := 0; i < len(parts); i++ {
 		if parts[i] == resourceType {

--- a/pkg/state_adapter_test.go
+++ b/pkg/state_adapter_test.go
@@ -55,7 +55,8 @@ func TestConvertInvolved(t *testing.T) {
 		t.Fatalf("failed to convert Terraform state: %v", err)
 	}
 
-	require.Len(t, data.Export.Deployment.Resources, 24)
+	// 24 original resources + 1 component for module.data_lake_bucket
+	require.Len(t, data.Export.Deployment.Resources, 25)
 }
 
 func TestConvertTwoModules(t *testing.T) {
@@ -115,7 +116,7 @@ func translateStateFromJson(ctx context.Context, tfStateJson string) (*Translate
 	if err != nil {
 		return nil, err
 	}
-	return TranslateState(ctx, tfState, nil, "dev", "test-project")
+	return TranslateState(ctx, tfState, nil, "dev", "test-project", true, nil)
 }
 
 func Test_convertState_simple(t *testing.T) {
@@ -130,7 +131,7 @@ func Test_convertState_simple(t *testing.T) {
 	pulumiProviders, err := GetPulumiProvidersForTerraformState(tfState, nil)
 	require.NoError(t, err, "failed to get Pulumi providers")
 
-	pulumiState, errorMessages, err := convertState(tfState, pulumiProviders)
+	pulumiState, errorMessages, err := convertState(tfState, pulumiProviders, false, nil)
 	require.NoError(t, err, "failed to convert state")
 	require.Equal(t, 0, len(errorMessages), "expected no error messages")
 
@@ -157,7 +158,7 @@ func Test_convertState_multi_provider(t *testing.T) {
 	pulumiProviders, err := GetPulumiProvidersForTerraformState(tfState, nil)
 	require.NoError(t, err, "failed to get Pulumi providers")
 
-	pulumiState, errorMessages, err := convertState(tfState, pulumiProviders)
+	pulumiState, errorMessages, err := convertState(tfState, pulumiProviders, false, nil)
 	require.NoError(t, err, "failed to convert state")
 	require.Equal(t, 0, len(errorMessages), "expected no error messages")
 
@@ -212,7 +213,7 @@ func Test_convertState_corrupted_state(t *testing.T) {
 	pulumiProviders, err := GetPulumiProvidersForTerraformState(tfState, nil)
 	require.NoError(t, err, "failed to get Pulumi providers")
 
-	_, errorMessages, err := convertState(tfState, pulumiProviders)
+	_, errorMessages, err := convertState(tfState, pulumiProviders, false, nil)
 	require.NoError(t, err, "failed to convert state")
 	require.Equal(t, 1, len(errorMessages), "expected 1 error message")
 	require.Equal(t, "password", errorMessages[0].ResourceName)
@@ -235,7 +236,7 @@ func Test_convertState_unknown_provider(t *testing.T) {
 
 	require.Len(t, pulumiProviders, 1, "should only have 1 provider (random)")
 
-	pulumiState, errorMessages, err := convertState(tfState, pulumiProviders)
+	pulumiState, errorMessages, err := convertState(tfState, pulumiProviders, false, nil)
 	require.NoError(t, err, "failed to convert state")
 
 	require.Len(t, errorMessages, 1, "expected 1 error message for unknown_resource")
@@ -287,6 +288,48 @@ func TestFormatDynamicProviderName(t *testing.T) {
 	}
 }
 
+func TestPulumiNameFromTerraformAddress_ShortName(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name         string
+		address      string
+		resourceType string
+		expected     string
+	}{
+		{
+			name:         "root module resource",
+			address:      "aws_s3_bucket.mybucket",
+			resourceType: "aws_s3_bucket",
+			expected:     "mybucket",
+		},
+		{
+			name:         "single module resource",
+			address:      "module.vpc.aws_subnet.this",
+			resourceType: "aws_subnet",
+			expected:     "this",
+		},
+		{
+			name:         "indexed module resource",
+			address:      "module.vpc[0].aws_subnet.this",
+			resourceType: "aws_subnet",
+			expected:     "this",
+		},
+		{
+			name:         "nested module resource",
+			address:      "module.vpc.module.subnets.aws_subnet.this",
+			resourceType: "aws_subnet",
+			expected:     "this",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := PulumiNameFromTerraformAddress(tc.address, tc.resourceType, true)
+			require.Equal(t, tc.expected, result)
+		})
+	}
+}
+
 func TestPulumiNameFromTerraformAddress(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
@@ -329,7 +372,7 @@ func TestPulumiNameFromTerraformAddress(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			result := PulumiNameFromTerraformAddress(tc.address, tc.resourceType)
+			result := PulumiNameFromTerraformAddress(tc.address, tc.resourceType, false)
 			require.Equal(t, tc.expected, result)
 		})
 	}

--- a/pkg/state_adapter_test.go
+++ b/pkg/state_adapter_test.go
@@ -77,6 +77,46 @@ func TestConvertTwoModules(t *testing.T) {
 	require.Equal(t, 2, len(bucketURNs), "expected 2 unique URNs for buckets")
 }
 
+func TestConvertTwoModules_FlatMode(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	tfState, err := tofu.LoadTerraformState(ctx, tofu.LoadTerraformStateOptions{
+		StateFilePath: "testdata/tofu_state_two_buckets.json",
+	})
+	require.NoError(t, err)
+
+	// enableComponents=false: flat mode, no component resources
+	data, err := TranslateState(ctx, tfState, nil, "dev", "test-project", false, nil)
+	require.NoError(t, err)
+
+	// No component resources in flat mode
+	for _, r := range data.Export.Deployment.Resources {
+		if !r.Custom && string(r.Type) != "pulumi:pulumi:Stack" {
+			t.Fatalf("unexpected component resource in flat mode: %s", r.Type)
+		}
+	}
+
+	// All resources parented to Stack
+	for _, r := range data.Export.Deployment.Resources {
+		if r.Custom && string(r.Type) != "pulumi:providers:aws" {
+			require.Contains(t, string(r.Parent), "pulumi:pulumi:Stack",
+				"resource %s should be parented to Stack in flat mode", r.URN)
+		}
+	}
+
+	// Names include module path (not short names)
+	bucketURNs := make(map[string]bool)
+	for _, r := range data.Export.Deployment.Resources {
+		if r.Type == "aws:s3/bucket:Bucket" {
+			bucketURNs[string(r.URN)] = true
+			// Flat mode names include module prefix
+			require.Contains(t, string(r.URN), "s3_bucket_",
+				"flat mode bucket URN should include module prefix")
+		}
+	}
+	require.Equal(t, 2, len(bucketURNs), "expected 2 unique bucket URNs")
+}
+
 func TestConvertNestedModules(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/pkg/statefile/translate.go
+++ b/pkg/statefile/translate.go
@@ -84,7 +84,7 @@ func TranslateResourceInstance(
 	return pkg.PulumiResource{
 		PulumiResourceID: pkg.PulumiResourceID{
 			ID:   props["id"].StringValue(),
-			Name: pkg.PulumiNameFromTerraformAddress(res.Addr.Instance(key).String(), resourceType),
+			Name: pkg.PulumiNameFromTerraformAddress(res.Addr.Instance(key).String(), resourceType, false),
 			Type: string(pulumiTypeToken),
 		},
 		Inputs:  inputs,

--- a/test/translate_test.go
+++ b/test/translate_test.go
@@ -101,7 +101,7 @@ func TestTranslateBasic(t *testing.T) {
 
 	ctx := context.Background()
 
-	err := pkg.TranslateAndWriteState(ctx, statePath, stackFolder, filepath.Join(stackFolder, "state.json"), "", false, "", "")
+	err := pkg.TranslateAndWriteState(ctx, statePath, stackFolder, filepath.Join(stackFolder, "state.json"), "", false, true, nil, "", "")
 	require.NoError(t, err)
 
 	_ = runCommand(t, stackFolder, "pulumi", "stack", "import", "--file", filepath.Join(stackFolder, "state.json"))
@@ -135,7 +135,7 @@ func TestTranslateBasicWithDependencies(t *testing.T) {
 	statePath := setupTFStack(t, "testdata/tf_random_stack")
 	stackFolder, _ := createPulumiStack(t)
 
-	err := pkg.TranslateAndWriteState(ctx, statePath, stackFolder, filepath.Join(stackFolder, "state.json"), filepath.Join(stackFolder, "dependencies.json"), false, "", "")
+	err := pkg.TranslateAndWriteState(ctx, statePath, stackFolder, filepath.Join(stackFolder, "state.json"), filepath.Join(stackFolder, "dependencies.json"), false, true, nil, "", "")
 	require.NoError(t, err)
 
 	dependencies, err := os.ReadFile(filepath.Join(stackFolder, "dependencies.json"))
@@ -151,7 +151,7 @@ func TestTranslateBasicWithEdit(t *testing.T) {
 	statePath := setupTFStack(t, "testdata/tf_random_stack")
 	stackFolder, stackName := createPulumiStack(t)
 
-	err := pkg.TranslateAndWriteState(ctx, statePath, stackFolder, filepath.Join(stackFolder, "state.json"), "", false, "", "")
+	err := pkg.TranslateAndWriteState(ctx, statePath, stackFolder, filepath.Join(stackFolder, "state.json"), "", false, true, nil, "", "")
 	require.NoError(t, err)
 
 	_ = runCommand(t, stackFolder, "pulumi", "stack", "import", "--file", filepath.Join(stackFolder, "state.json"))
@@ -209,7 +209,7 @@ func TestTranslateWithDependency(t *testing.T) {
 	statePath := setupTFStack(t, "testdata/tf_dependency_stack")
 	stackFolder, stackName := createPulumiStack(t)
 
-	err := pkg.TranslateAndWriteState(ctx, statePath, stackFolder, filepath.Join(stackFolder, "state.json"), "", false, "", "")
+	err := pkg.TranslateAndWriteState(ctx, statePath, stackFolder, filepath.Join(stackFolder, "state.json"), "", false, true, nil, "", "")
 	require.NoError(t, err)
 
 	_ = runCommand(t, stackFolder, "pulumi", "stack", "import", "--file", filepath.Join(stackFolder, "state.json"))


### PR DESCRIPTION
**Design & Plan:** [`feat/module-to-component-design`](https://github.com/pulumi/pulumi-tool-terraform-migrate/tree/feat/module-to-component-design) ([spec](https://github.com/pulumi/pulumi-tool-terraform-migrate/blob/feat/module-to-component-design/docs/superpowers/specs/2026-03-31-module-to-component-design.md) · [plan](https://github.com/pulumi/pulumi-tool-terraform-migrate/blob/feat/module-to-component-design/docs/superpowers/plans/2026-03-31-module-to-component.md))


feat: integrate module tree into convertState pipeline + CLI flags

- Thread enableComponents/typeOverrides through TranslateAndWriteState,
  TranslateState, and convertState
- Build component tree in convertState when enabled, set parent type
  chains on resources, use short names
- Add --no-module-components and --module-type-map CLI flags
- Add PulumiNameFromTerraformAddress short name support
- Update all call sites for new signatures

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

Revert "docs: add spec for decoupling state translation from Pulumi workspace"

This reverts commit b6264911da0d921a1bce9d197e9a50bafa0b5bb9.

test: add TestConvertTwoModules_FlatMode backward compat test

Verifies that enableComponents=false produces flat output: no component
resources, all resources parented to Stack, names include module prefix.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>