### PR TITLE
feat/mc-05-schema-validation

### DIFF
--- a/cmd/stack.go
+++ b/cmd/stack.go
@@ -33,6 +33,7 @@ func newStackCmd() *cobra.Command {
 	var moduleTypeMaps []string
 	var pulumiStack string
 	var pulumiProject string
+	var moduleSchemas []string
 
 	cmd := &cobra.Command{
 		Use:   "stack",
@@ -83,6 +84,16 @@ See also:
 				typeOverrides[parts[0]] = parts[1]
 			}
 
+			schemaOverrides := map[string]string{}
+			for _, mapping := range moduleSchemas {
+				parts := strings.SplitN(mapping, "=", 2)
+				if len(parts) != 2 {
+					return fmt.Errorf("invalid --module-schema format %q, expected module.name=./path/to/schema.json", mapping)
+				}
+				schemaOverrides[parts[0]] = parts[1]
+			}
+			_ = schemaOverrides // TODO: wire into pipeline in Phase 2 (PR 9)
+
 			enableComponents := !noModuleComponents
 			if noModuleComponents && len(moduleTypeMaps) > 0 {
 				fmt.Fprintf(os.Stderr, "Warning: --module-type-map is ignored when --no-module-components is set\n")
@@ -108,6 +119,8 @@ See also:
 		"Override component type token for a module (repeatable, format: module.name=pkg:mod:Type)")
 	cmd.Flags().StringVar(&pulumiStack, "pulumi-stack", "", "Override Pulumi stack name (skip auto-detection)")
 	cmd.Flags().StringVar(&pulumiProject, "pulumi-project", "", "Override Pulumi project name (skip auto-detection)")
+	cmd.Flags().StringArrayVar(&moduleSchemas, "module-schema", nil,
+		"Pulumi package schema for component validation (repeatable, format: module.name=./path/to/schema.json)")
 
 	cmd.MarkFlagRequired("from")
 	cmd.MarkFlagRequired("to")

--- a/pkg/component_schema.go
+++ b/pkg/component_schema.go
@@ -1,0 +1,109 @@
+// Copyright 2016-2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pkg
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+)
+
+// ComponentField represents a single input or output field of a component.
+type ComponentField struct {
+	Name     string
+	Required bool
+}
+
+// ComponentInterface represents the inputs and outputs of a component resource.
+type ComponentInterface struct {
+	Inputs  []ComponentField
+	Outputs []ComponentField
+}
+
+// LoadComponentSchema loads a Pulumi package schema JSON file and extracts the
+// component interface (inputs and outputs) for the given component type token.
+func LoadComponentSchema(schemaPath string, componentType string) (*ComponentInterface, error) {
+	data, err := os.ReadFile(schemaPath)
+	if err != nil {
+		return nil, fmt.Errorf("reading schema file: %w", err)
+	}
+
+	var spec schema.PackageSpec
+	if err := json.Unmarshal(data, &spec); err != nil {
+		return nil, fmt.Errorf("parsing schema JSON: %w", err)
+	}
+
+	pkg, diags, err := schema.BindSpec(spec, nil, schema.ValidationOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("binding schema spec: %w", err)
+	}
+	if diags.HasErrors() {
+		return nil, fmt.Errorf("schema validation errors: %s", diags.Error())
+	}
+
+	resource, ok := pkg.GetResource(componentType)
+	if !ok {
+		return nil, fmt.Errorf("component type %q not found in schema", componentType)
+	}
+	if !resource.IsComponent {
+		return nil, fmt.Errorf("resource %q is not a component (isComponent=false)", componentType)
+	}
+
+	iface := &ComponentInterface{}
+
+	for _, prop := range resource.InputProperties {
+		iface.Inputs = append(iface.Inputs, ComponentField{
+			Name:     prop.Name,
+			Required: prop.IsRequired(),
+		})
+	}
+
+	for _, prop := range resource.Properties {
+		iface.Outputs = append(iface.Outputs, ComponentField{
+			Name: prop.Name,
+		})
+	}
+
+	return iface, nil
+}
+
+// ValidateAgainstSchema validates that a parsed component interface matches a schema.
+// Schema is source of truth — mismatch is an error. Type compatibility is handled by
+// the value conversion pipeline (cty.Value → resource.PropertyMap via tfbridge), not here.
+func ValidateAgainstSchema(parsed *ComponentInterface, schemaIface *ComponentInterface) error {
+	parsedInputs := map[string]bool{}
+	for _, f := range parsed.Inputs {
+		parsedInputs[f.Name] = true
+	}
+	for _, f := range schemaIface.Inputs {
+		if f.Required && !parsedInputs[f.Name] {
+			return fmt.Errorf("input %q is required by schema but not found in parsed interface", f.Name)
+		}
+	}
+
+	schemaOutputs := map[string]bool{}
+	for _, f := range schemaIface.Outputs {
+		schemaOutputs[f.Name] = true
+	}
+	for _, f := range parsed.Outputs {
+		if !schemaOutputs[f.Name] {
+			return fmt.Errorf("output %q not in schema", f.Name)
+		}
+	}
+
+	return nil
+}

--- a/pkg/component_schema_test.go
+++ b/pkg/component_schema_test.go
@@ -1,0 +1,148 @@
+// Copyright 2016-2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pkg
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadComponentSchema(t *testing.T) {
+	t.Parallel()
+	iface, err := LoadComponentSchema("testdata/schemas/vpc_component_schema.json", "myproject:index:VpcComponent")
+	require.NoError(t, err)
+	require.Len(t, iface.Inputs, 2)
+	require.Len(t, iface.Outputs, 1)
+
+	cidr := findField(iface.Inputs, "cidr")
+	require.NotNil(t, cidr)
+	require.True(t, cidr.Required)
+
+	name := findField(iface.Inputs, "name")
+	require.NotNil(t, name)
+	require.True(t, name.Required)
+
+	vpcId := findField(iface.Outputs, "vpcId")
+	require.NotNil(t, vpcId)
+}
+
+func TestLoadComponentSchema_NotFound(t *testing.T) {
+	t.Parallel()
+	_, err := LoadComponentSchema("testdata/schemas/vpc_component_schema.json", "myproject:index:DoesNotExist")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not found")
+}
+
+func TestLoadComponentSchema_NotComponent(t *testing.T) {
+	t.Parallel()
+	_, err := LoadComponentSchema("testdata/schemas/vpc_component_schema.json", "myproject:index:NotAComponent")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not a component")
+}
+
+func TestLoadComponentSchema_FileNotFound(t *testing.T) {
+	t.Parallel()
+	_, err := LoadComponentSchema("testdata/schemas/nonexistent.json", "myproject:index:VpcComponent")
+	require.Error(t, err)
+}
+
+func TestValidateAgainstSchema_Match(t *testing.T) {
+	t.Parallel()
+	schema := &ComponentInterface{
+		Inputs: []ComponentField{
+			{Name: "cidr", Required: true},
+			{Name: "name", Required: true},
+		},
+		Outputs: []ComponentField{
+			{Name: "vpcId"},
+		},
+	}
+	parsed := &ComponentInterface{
+		Inputs: []ComponentField{
+			{Name: "cidr"},
+			{Name: "name"},
+		},
+		Outputs: []ComponentField{
+			{Name: "vpcId"},
+		},
+	}
+	err := ValidateAgainstSchema(parsed, schema)
+	require.NoError(t, err)
+}
+
+func TestValidateAgainstSchema_MissingRequiredInput(t *testing.T) {
+	t.Parallel()
+	schema := &ComponentInterface{
+		Inputs: []ComponentField{
+			{Name: "cidr", Required: true},
+			{Name: "name", Required: true},
+		},
+	}
+	parsed := &ComponentInterface{
+		Inputs: []ComponentField{
+			{Name: "cidr"},
+		},
+	}
+	err := ValidateAgainstSchema(parsed, schema)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "name")
+	require.Contains(t, err.Error(), "required")
+}
+
+func TestValidateAgainstSchema_ExtraOutput(t *testing.T) {
+	t.Parallel()
+	schema := &ComponentInterface{
+		Outputs: []ComponentField{
+			{Name: "vpcId"},
+		},
+	}
+	parsed := &ComponentInterface{
+		Outputs: []ComponentField{
+			{Name: "vpcId"},
+			{Name: "extraField"},
+		},
+	}
+	err := ValidateAgainstSchema(parsed, schema)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "extraField")
+	require.Contains(t, err.Error(), "not in schema")
+}
+
+func TestValidateAgainstSchema_OptionalInputMissing(t *testing.T) {
+	t.Parallel()
+	schema := &ComponentInterface{
+		Inputs: []ComponentField{
+			{Name: "cidr", Required: true},
+			{Name: "tags", Required: false},
+		},
+	}
+	parsed := &ComponentInterface{
+		Inputs: []ComponentField{
+			{Name: "cidr"},
+		},
+	}
+	err := ValidateAgainstSchema(parsed, schema)
+	require.NoError(t, err)
+}
+
+func findField(fields []ComponentField, name string) *ComponentField {
+	for i := range fields {
+		if fields[i].Name == name {
+			return &fields[i]
+		}
+	}
+	return nil
+}

--- a/pkg/testdata/schemas/vpc_component_schema.json
+++ b/pkg/testdata/schemas/vpc_component_schema.json
@@ -1,0 +1,32 @@
+{
+  "name": "myproject",
+  "version": "0.1.0",
+  "resources": {
+    "myproject:index:VpcComponent": {
+      "isComponent": true,
+      "inputProperties": {
+        "cidr": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "requiredInputs": ["cidr", "name"],
+      "properties": {
+        "vpcId": {
+          "type": "string"
+        }
+      },
+      "required": ["vpcId"]
+    },
+    "myproject:index:NotAComponent": {
+      "isComponent": false,
+      "inputProperties": {
+        "foo": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
**Design & Plan:** [`feat/module-to-component-design`](https://github.com/pulumi/pulumi-tool-terraform-migrate/tree/feat/module-to-component-design) ([spec](https://github.com/pulumi/pulumi-tool-terraform-migrate/blob/feat/module-to-component-design/docs/superpowers/specs/2026-03-31-module-to-component-design.md) · [plan](https://github.com/pulumi/pulumi-tool-terraform-migrate/blob/feat/module-to-component-design/docs/superpowers/plans/2026-03-31-module-to-component.md))


- LoadComponentSchema loads Pulumi package schema JSON and extracts
  component interface (field names + required) using codegen/schema.BindSpec
- ValidateAgainstSchema checks field presence: missing required input = error,
  extra output not in schema = error. Type compatibility is handled by the
  value conversion pipeline (cty → PropertyMap via tfbridge), not here.
- Add --module-schema CLI flag (parsed, wired in Phase 2)
- Test fixture with component + non-component resources

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>