### PR TITLE
feat/mc-07-hcl-parser

### DIFF
--- a/pkg/hcl/parser.go
+++ b/pkg/hcl/parser.go
@@ -1,0 +1,144 @@
+// Copyright 2016-2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hcl
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/ext/typeexpr"
+	"github.com/hashicorp/hcl/v2/hclparse"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// ModuleVariable represents a parsed variable block from a Terraform module.
+type ModuleVariable struct {
+	Name        string
+	Type        string     // HCL type constraint string (e.g., "string", "map(string)")
+	Default     *cty.Value // nil if no default (variable is required)
+	Description string
+}
+
+// ModuleOutput represents a parsed output block from a Terraform module.
+type ModuleOutput struct {
+	Name        string
+	Description string
+	Expression  hcl.Expression // raw HCL expression for later evaluation
+}
+
+// ParseModuleVariables parses all .tf files in moduleDir and extracts variable blocks.
+func ParseModuleVariables(moduleDir string) ([]ModuleVariable, error) {
+	files, err := parseTFFiles(moduleDir)
+	if err != nil {
+		return nil, err
+	}
+
+	var vars []ModuleVariable
+	for _, file := range files {
+		body, ok := file.Body.(*hclsyntax.Body)
+		if !ok {
+			continue
+		}
+		for _, block := range body.Blocks {
+			if block.Type != "variable" || len(block.Labels) == 0 {
+				continue
+			}
+			v := ModuleVariable{Name: block.Labels[0]}
+
+			attrs, _ := block.Body.JustAttributes()
+			if typeAttr, ok := attrs["type"]; ok {
+				ty, diags := typeexpr.TypeConstraint(typeAttr.Expr)
+				if !diags.HasErrors() {
+					v.Type = typeexpr.TypeString(ty)
+				}
+			}
+			if descAttr, ok := attrs["description"]; ok {
+				val, diags := descAttr.Expr.Value(nil)
+				if !diags.HasErrors() {
+					v.Description = val.AsString()
+				}
+			}
+			if defaultAttr, ok := attrs["default"]; ok {
+				val, diags := defaultAttr.Expr.Value(nil)
+				if !diags.HasErrors() {
+					v.Default = &val
+				}
+			}
+
+			vars = append(vars, v)
+		}
+	}
+	return vars, nil
+}
+
+// ParseModuleOutputs parses all .tf files in moduleDir and extracts output blocks.
+func ParseModuleOutputs(moduleDir string) ([]ModuleOutput, error) {
+	files, err := parseTFFiles(moduleDir)
+	if err != nil {
+		return nil, err
+	}
+
+	var outputs []ModuleOutput
+	for _, file := range files {
+		body, ok := file.Body.(*hclsyntax.Body)
+		if !ok {
+			continue
+		}
+		for _, block := range body.Blocks {
+			if block.Type != "output" || len(block.Labels) == 0 {
+				continue
+			}
+			o := ModuleOutput{Name: block.Labels[0]}
+
+			attrs, _ := block.Body.JustAttributes()
+			if descAttr, ok := attrs["description"]; ok {
+				val, diags := descAttr.Expr.Value(nil)
+				if !diags.HasErrors() {
+					o.Description = val.AsString()
+				}
+			}
+			if valueAttr, ok := attrs["value"]; ok {
+				o.Expression = valueAttr.Expr
+			}
+
+			outputs = append(outputs, o)
+		}
+	}
+	return outputs, nil
+}
+
+// parseTFFiles parses all .tf files in a directory.
+func parseTFFiles(dir string) ([]*hcl.File, error) {
+	matches, err := filepath.Glob(filepath.Join(dir, "*.tf"))
+	if err != nil {
+		return nil, fmt.Errorf("globbing .tf files in %s: %w", dir, err)
+	}
+	if len(matches) == 0 {
+		return nil, fmt.Errorf("no .tf files found in %s", dir)
+	}
+
+	parser := hclparse.NewParser()
+	var files []*hcl.File
+	for _, path := range matches {
+		f, diags := parser.ParseHCLFile(path)
+		if diags.HasErrors() {
+			return nil, fmt.Errorf("parsing %s: %s", path, diags.Error())
+		}
+		files = append(files, f)
+	}
+	return files, nil
+}

--- a/pkg/hcl/parser_test.go
+++ b/pkg/hcl/parser_test.go
@@ -1,0 +1,92 @@
+// Copyright 2016-2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hcl
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseModuleVariables(t *testing.T) {
+	t.Parallel()
+	vars, err := ParseModuleVariables("testdata/pet_module")
+	require.NoError(t, err)
+	require.Len(t, vars, 3)
+
+	prefix := findVar(vars, "prefix")
+	require.NotNil(t, prefix)
+	require.Equal(t, "string", prefix.Type)
+	require.Nil(t, prefix.Default)
+	require.Equal(t, "Prefix for the pet name", prefix.Description)
+
+	separator := findVar(vars, "separator")
+	require.NotNil(t, separator)
+	require.Equal(t, "string", separator.Type)
+	require.NotNil(t, separator.Default)
+	require.Equal(t, "-", separator.Default.AsString())
+
+	length := findVar(vars, "length")
+	require.NotNil(t, length)
+	require.Equal(t, "number", length.Type)
+	require.NotNil(t, length.Default)
+}
+
+func TestParseModuleOutputs(t *testing.T) {
+	t.Parallel()
+	outputs, err := ParseModuleOutputs("testdata/pet_module")
+	require.NoError(t, err)
+	require.Len(t, outputs, 2)
+
+	name := findOutput(outputs, "name")
+	require.NotNil(t, name)
+	require.Equal(t, "The generated pet name", name.Description)
+	require.NotNil(t, name.Expression)
+
+	separator := findOutput(outputs, "separator")
+	require.NotNil(t, separator)
+	require.Empty(t, separator.Description)
+	require.NotNil(t, separator.Expression)
+}
+
+func TestParseModuleVariables_NonexistentDir(t *testing.T) {
+	t.Parallel()
+	_, err := ParseModuleVariables("testdata/nonexistent")
+	require.Error(t, err)
+}
+
+func TestParseModuleOutputs_NonexistentDir(t *testing.T) {
+	t.Parallel()
+	_, err := ParseModuleOutputs("testdata/nonexistent")
+	require.Error(t, err)
+}
+
+func findVar(vars []ModuleVariable, name string) *ModuleVariable {
+	for i := range vars {
+		if vars[i].Name == name {
+			return &vars[i]
+		}
+	}
+	return nil
+}
+
+func findOutput(outputs []ModuleOutput, name string) *ModuleOutput {
+	for i := range outputs {
+		if outputs[i].Name == name {
+			return &outputs[i]
+		}
+	}
+	return nil
+}

--- a/pkg/hcl/testdata/pet_module/main.tf
+++ b/pkg/hcl/testdata/pet_module/main.tf
@@ -1,0 +1,5 @@
+resource "random_pet" "this" {
+  prefix    = var.prefix
+  separator = var.separator
+  length    = var.length
+}

--- a/pkg/hcl/testdata/pet_module/outputs.tf
+++ b/pkg/hcl/testdata/pet_module/outputs.tf
@@ -1,0 +1,8 @@
+output "name" {
+  value       = random_pet.this.id
+  description = "The generated pet name"
+}
+
+output "separator" {
+  value = random_pet.this.separator
+}

--- a/pkg/hcl/testdata/pet_module/variables.tf
+++ b/pkg/hcl/testdata/pet_module/variables.tf
@@ -1,0 +1,14 @@
+variable "prefix" {
+  type        = string
+  description = "Prefix for the pet name"
+}
+
+variable "separator" {
+  type    = string
+  default = "-"
+}
+
+variable "length" {
+  type    = number
+  default = 2
+}


### PR DESCRIPTION
**Design & Plan:** [`feat/module-to-component-design`](https://github.com/pulumi/pulumi-tool-terraform-migrate/tree/feat/module-to-component-design) ([spec](https://github.com/pulumi/pulumi-tool-terraform-migrate/blob/feat/module-to-component-design/docs/superpowers/specs/2026-03-31-module-to-component-design.md) · [plan](https://github.com/pulumi/pulumi-tool-terraform-migrate/blob/feat/module-to-component-design/docs/superpowers/plans/2026-03-31-module-to-component.md))


- ParseModuleVariables: extracts name, type (via ext/typeexpr), default,
  description from variable blocks in .tf files
- ParseModuleOutputs: extracts name, description, and preserves raw HCL
  expression for later evaluation
- Test fixture: real pet module with string/number variables and outputs

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>