### PR TITLE
feat/mc-08-callsite-tfvars

### DIFF
--- a/pkg/hcl/parser.go
+++ b/pkg/hcl/parser.go
@@ -121,6 +121,99 @@ func ParseModuleOutputs(moduleDir string) ([]ModuleOutput, error) {
 	return outputs, nil
 }
 
+// ModuleCallSite represents a parsed module block from a root Terraform configuration.
+type ModuleCallSite struct {
+	Name      string
+	Source    string
+	Arguments map[string]hcl.Expression // argument name -> expression (excludes source, version, count, for_each, providers, depends_on)
+}
+
+// metaArguments are module block attributes that are not passed as input arguments.
+var metaArguments = map[string]bool{
+	"source":     true,
+	"version":    true,
+	"count":      true,
+	"for_each":   true,
+	"providers":  true,
+	"depends_on": true,
+}
+
+// ParseModuleCallSites parses all .tf files in rootDir and extracts module call blocks.
+func ParseModuleCallSites(rootDir string) ([]ModuleCallSite, error) {
+	files, err := parseTFFiles(rootDir)
+	if err != nil {
+		return nil, err
+	}
+
+	var calls []ModuleCallSite
+	for _, file := range files {
+		body, ok := file.Body.(*hclsyntax.Body)
+		if !ok {
+			continue
+		}
+		for _, block := range body.Blocks {
+			if block.Type != "module" || len(block.Labels) == 0 {
+				continue
+			}
+			c := ModuleCallSite{
+				Name:      block.Labels[0],
+				Arguments: map[string]hcl.Expression{},
+			}
+
+			attrs, _ := block.Body.JustAttributes()
+			if sourceAttr, ok := attrs["source"]; ok {
+				val, diags := sourceAttr.Expr.Value(nil)
+				if !diags.HasErrors() {
+					c.Source = val.AsString()
+				}
+			}
+			for name, attr := range attrs {
+				if !metaArguments[name] {
+					c.Arguments[name] = attr.Expr
+				}
+			}
+
+			calls = append(calls, c)
+		}
+	}
+	return calls, nil
+}
+
+// LoadTfvars loads a terraform.tfvars file and returns the values as a map.
+// Returns an empty map (not an error) if the file doesn't exist.
+func LoadTfvars(path string) (map[string]cty.Value, error) {
+	parser := hclparse.NewParser()
+	f, diags := parser.ParseHCLFile(path)
+	if diags.HasErrors() {
+		// Check if file doesn't exist
+		for _, d := range diags {
+			if d.Summary == "Failed to read file" {
+				return map[string]cty.Value{}, nil
+			}
+		}
+		return nil, fmt.Errorf("parsing tfvars %s: %s", path, diags.Error())
+	}
+
+	body, ok := f.Body.(*hclsyntax.Body)
+	if !ok {
+		return map[string]cty.Value{}, nil
+	}
+
+	attrs, diags := body.JustAttributes()
+	if diags.HasErrors() {
+		return nil, fmt.Errorf("reading tfvars attributes: %s", diags.Error())
+	}
+
+	values := map[string]cty.Value{}
+	for name, attr := range attrs {
+		val, diags := attr.Expr.Value(nil)
+		if !diags.HasErrors() {
+			values[name] = val
+		}
+	}
+	return values, nil
+}
+
 // parseTFFiles parses all .tf files in a directory.
 func parseTFFiles(dir string) ([]*hcl.File, error) {
 	matches, err := filepath.Glob(filepath.Join(dir, "*.tf"))

--- a/pkg/hcl/parser_test.go
+++ b/pkg/hcl/parser_test.go
@@ -73,6 +73,53 @@ func TestParseModuleOutputs_NonexistentDir(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestParseModuleCallSites(t *testing.T) {
+	t.Parallel()
+	calls, err := ParseModuleCallSites("testdata/root_with_pet")
+	require.NoError(t, err)
+	require.Len(t, calls, 2)
+
+	pet := findCall(calls, "pet")
+	require.NotNil(t, pet)
+	require.Equal(t, "../pet_module", pet.Source)
+	require.Len(t, pet.Arguments, 1) // prefix (count is not an argument)
+
+	named := findCall(calls, "named_pet")
+	require.NotNil(t, named)
+	require.Equal(t, "../pet_module", named.Source)
+	require.Len(t, named.Arguments, 3) // prefix, separator, length
+}
+
+func TestParseModuleCallSites_NonexistentDir(t *testing.T) {
+	t.Parallel()
+	_, err := ParseModuleCallSites("testdata/nonexistent")
+	require.Error(t, err)
+}
+
+func TestLoadTfvars(t *testing.T) {
+	t.Parallel()
+	vars, err := LoadTfvars("testdata/root_with_pet/terraform.tfvars")
+	require.NoError(t, err)
+	require.Len(t, vars, 1)
+	require.Equal(t, "production", vars["env"].AsString())
+}
+
+func TestLoadTfvars_NotFound(t *testing.T) {
+	t.Parallel()
+	vars, err := LoadTfvars("testdata/nonexistent/terraform.tfvars")
+	require.NoError(t, err)
+	require.Len(t, vars, 0)
+}
+
+func findCall(calls []ModuleCallSite, name string) *ModuleCallSite {
+	for i := range calls {
+		if calls[i].Name == name {
+			return &calls[i]
+		}
+	}
+	return nil
+}
+
 func findVar(vars []ModuleVariable, name string) *ModuleVariable {
 	for i := range vars {
 		if vars[i].Name == name {

--- a/pkg/hcl/testdata/root_with_pet/main.tf
+++ b/pkg/hcl/testdata/root_with_pet/main.tf
@@ -1,0 +1,17 @@
+variable "env" {
+  type    = string
+  default = "dev"
+}
+
+module "pet" {
+  count  = 2
+  source = "../pet_module"
+  prefix = "test-${count.index}"
+}
+
+module "named_pet" {
+  source    = "../pet_module"
+  prefix    = var.env
+  separator = "_"
+  length    = 3
+}

--- a/pkg/hcl/testdata/root_with_pet/terraform.tfvars
+++ b/pkg/hcl/testdata/root_with_pet/terraform.tfvars
@@ -1,0 +1,1 @@
+env = "production"


### PR DESCRIPTION
**Design & Plan:** [`feat/module-to-component-design`](https://github.com/pulumi/pulumi-tool-terraform-migrate/tree/feat/module-to-component-design) ([spec](https://github.com/pulumi/pulumi-tool-terraform-migrate/blob/feat/module-to-component-design/docs/superpowers/specs/2026-03-31-module-to-component-design.md) · [plan](https://github.com/pulumi/pulumi-tool-terraform-migrate/blob/feat/module-to-component-design/docs/superpowers/plans/2026-03-31-module-to-component.md))


- ParseModuleCallSites: extracts module name, source, and argument
  expressions from module blocks (excludes meta-arguments: source,
  version, count, for_each, providers, depends_on)
- LoadTfvars: loads terraform.tfvars as cty.Value map, returns empty
  map (not error) if file doesn't exist
- Test fixtures: root module calling pet_module with count and literal
  args, terraform.tfvars with env variable

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>