### PR TITLE
feat/mc-09-evaluator

### DIFF
--- a/pkg/hcl/evaluator.go
+++ b/pkg/hcl/evaluator.go
@@ -1,0 +1,81 @@
+// Copyright 2016-2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hcl
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/pulumi/opentofu/lang"
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/function"
+)
+
+// EvalContext wraps an HCL evaluation context populated with Terraform state data
+// and the full Terraform function library.
+type EvalContext struct {
+	hclCtx *hcl.EvalContext
+}
+
+// NewEvalContext creates an HCL evaluation context.
+//
+// Parameters:
+//   - variables: var.* namespace values (from tfvars or variable defaults)
+//   - resources: resource type -> instance name -> attributes object (from TF state)
+//   - moduleOutputs: module name -> output name -> value (from TF state)
+func NewEvalContext(
+	variables map[string]cty.Value,
+	resources map[string]map[string]cty.Value,
+	moduleOutputs map[string]map[string]cty.Value,
+) *EvalContext {
+	ctx := &hcl.EvalContext{
+		Variables: map[string]cty.Value{},
+		Functions: buildFunctionTable(),
+	}
+
+	if len(variables) > 0 {
+		ctx.Variables["var"] = cty.ObjectVal(variables)
+	}
+
+	for resType, instances := range resources {
+		ctx.Variables[resType] = cty.ObjectVal(instances)
+	}
+
+	if len(moduleOutputs) > 0 {
+		modVals := map[string]cty.Value{}
+		for modName, outputs := range moduleOutputs {
+			modVals[modName] = cty.ObjectVal(outputs)
+		}
+		ctx.Variables["module"] = cty.ObjectVal(modVals)
+	}
+
+	return &EvalContext{hclCtx: ctx}
+}
+
+// EvaluateExpression evaluates an HCL expression against the context.
+func (e *EvalContext) EvaluateExpression(expr hcl.Expression) (cty.Value, error) {
+	val, diags := expr.Value(e.hclCtx)
+	if diags.HasErrors() {
+		return cty.NilVal, fmt.Errorf("expression evaluation failed: %s", diags.Error())
+	}
+	return val, nil
+}
+
+// buildFunctionTable returns the full Terraform-compatible function table
+// using opentofu/lang.Scope which provides all standard + Terraform-specific functions.
+func buildFunctionTable() map[string]function.Function {
+	scope := &lang.Scope{BaseDir: "."}
+	return scope.Functions()
+}

--- a/pkg/hcl/evaluator_test.go
+++ b/pkg/hcl/evaluator_test.go
@@ -1,0 +1,126 @@
+// Copyright 2016-2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hcl
+
+import (
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/stretchr/testify/require"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func parseExpr(t *testing.T, src string) hcl.Expression {
+	t.Helper()
+	expr, diags := hclsyntax.ParseExpression([]byte(src), "test.hcl", hcl.Pos{})
+	require.False(t, diags.HasErrors(), diags.Error())
+	return expr
+}
+
+func TestEvaluateLiteral(t *testing.T) {
+	t.Parallel()
+	ctx := NewEvalContext(nil, nil, nil)
+	val, err := ctx.EvaluateExpression(parseExpr(t, `"10.0.0.0/16"`))
+	require.NoError(t, err)
+	require.Equal(t, "10.0.0.0/16", val.AsString())
+}
+
+func TestEvaluateVariableRef(t *testing.T) {
+	t.Parallel()
+	vars := map[string]cty.Value{"cidr": cty.StringVal("10.0.0.0/16")}
+	ctx := NewEvalContext(vars, nil, nil)
+	val, err := ctx.EvaluateExpression(parseExpr(t, "var.cidr"))
+	require.NoError(t, err)
+	require.Equal(t, "10.0.0.0/16", val.AsString())
+}
+
+func TestEvaluateResourceRef(t *testing.T) {
+	t.Parallel()
+	resources := map[string]map[string]cty.Value{
+		"random_pet": {"this": cty.ObjectVal(map[string]cty.Value{
+			"id":        cty.StringVal("test-0-creative-doberman"),
+			"prefix":    cty.StringVal("test-0"),
+			"separator": cty.StringVal("-"),
+		})},
+	}
+	ctx := NewEvalContext(nil, resources, nil)
+	val, err := ctx.EvaluateExpression(parseExpr(t, "random_pet.this.id"))
+	require.NoError(t, err)
+	require.Equal(t, "test-0-creative-doberman", val.AsString())
+}
+
+func TestEvaluateModuleOutputRef(t *testing.T) {
+	t.Parallel()
+	moduleOutputs := map[string]map[string]cty.Value{
+		"pet": {"name": cty.StringVal("test-0-creative-doberman")},
+	}
+	ctx := NewEvalContext(nil, nil, moduleOutputs)
+	val, err := ctx.EvaluateExpression(parseExpr(t, "module.pet.name"))
+	require.NoError(t, err)
+	require.Equal(t, "test-0-creative-doberman", val.AsString())
+}
+
+func TestEvaluateFunction_Join(t *testing.T) {
+	t.Parallel()
+	ctx := NewEvalContext(nil, nil, nil)
+	val, err := ctx.EvaluateExpression(parseExpr(t, `join("-", ["a", "b", "c"])`))
+	require.NoError(t, err)
+	require.Equal(t, "a-b-c", val.AsString())
+}
+
+func TestEvaluateFunction_Upper(t *testing.T) {
+	t.Parallel()
+	ctx := NewEvalContext(nil, nil, nil)
+	val, err := ctx.EvaluateExpression(parseExpr(t, `upper("hello")`))
+	require.NoError(t, err)
+	require.Equal(t, "HELLO", val.AsString())
+}
+
+func TestEvaluateConditional(t *testing.T) {
+	t.Parallel()
+	vars := map[string]cty.Value{"enable": cty.True}
+	ctx := NewEvalContext(vars, nil, nil)
+	val, err := ctx.EvaluateExpression(parseExpr(t, `var.enable ? "yes" : "no"`))
+	require.NoError(t, err)
+	require.Equal(t, "yes", val.AsString())
+}
+
+func TestEvaluateForExpression(t *testing.T) {
+	t.Parallel()
+	vars := map[string]cty.Value{
+		"names": cty.ListVal([]cty.Value{cty.StringVal("a"), cty.StringVal("b")}),
+	}
+	ctx := NewEvalContext(vars, nil, nil)
+	val, err := ctx.EvaluateExpression(parseExpr(t, `[for s in var.names : upper(s)]`))
+	require.NoError(t, err)
+	require.Equal(t, 2, val.LengthInt())
+}
+
+func TestEvaluateUnsupportedFunction(t *testing.T) {
+	t.Parallel()
+	ctx := NewEvalContext(nil, nil, nil)
+	_, err := ctx.EvaluateExpression(parseExpr(t, `totally_fake_function("x")`))
+	require.Error(t, err)
+}
+
+func TestEvaluateStringInterpolation(t *testing.T) {
+	t.Parallel()
+	vars := map[string]cty.Value{"prefix": cty.StringVal("test")}
+	ctx := NewEvalContext(vars, nil, nil)
+	val, err := ctx.EvaluateExpression(parseExpr(t, `"${var.prefix}-0"`))
+	require.NoError(t, err)
+	require.Equal(t, "test-0", val.AsString())
+}


### PR DESCRIPTION
**Design & Plan:** [`feat/module-to-component-design`](https://github.com/pulumi/pulumi-tool-terraform-migrate/tree/feat/module-to-component-design) ([spec](https://github.com/pulumi/pulumi-tool-terraform-migrate/blob/feat/module-to-component-design/docs/superpowers/specs/2026-03-31-module-to-component-design.md) · [plan](https://github.com/pulumi/pulumi-tool-terraform-migrate/blob/feat/module-to-component-design/docs/superpowers/plans/2026-03-31-module-to-component.md))


- NewEvalContext builds HCL eval context with var.*, resource, and
  module.* namespaces populated from TF state data
- EvaluateExpression evaluates HCL expressions against the context
- buildFunctionTable uses opentofu/lang.Scope.Functions() to get the
  full Terraform function library (join, upper, cidrsubnet, etc.)
- Tests cover: literals, variable refs, resource refs, module output
  refs, function calls, conditionals, for expressions, interpolation,
  unsupported function error

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>