### PR TITLE
feat/mc-11-component-inputs

### DIFF
--- a/cmd/stack.go
+++ b/cmd/stack.go
@@ -34,6 +34,7 @@ func newStackCmd() *cobra.Command {
 	var pulumiStack string
 	var pulumiProject string
 	var moduleSchemas []string
+	var componentInputs bool
 	var moduleSourceMaps []string
 
 	cmd := &cobra.Command{
@@ -109,7 +110,7 @@ See also:
 				typeOverrides = nil
 			}
 
-			err := pkg.TranslateAndWriteState(cmd.Context(), from, to, out, plugins, strict, enableComponents, typeOverrides, sourceOverrides, schemaOverrides, pulumiStack, pulumiProject)
+			err := pkg.TranslateAndWriteState(cmd.Context(), from, to, out, plugins, strict, enableComponents, componentInputs, typeOverrides, sourceOverrides, schemaOverrides, pulumiStack, pulumiProject)
 			if err != nil {
 				return fmt.Errorf("failed to convert and write Terraform state: %w", err)
 			}
@@ -130,6 +131,8 @@ See also:
 	cmd.Flags().StringVar(&pulumiProject, "pulumi-project", "", "Override Pulumi project name (skip auto-detection)")
 	cmd.Flags().StringArrayVar(&moduleSchemas, "module-schema", nil,
 		"Pulumi package schema for component validation (repeatable, format: module.name=./path/to/schema.json)")
+	cmd.Flags().BoolVar(&componentInputs, "component-inputs", true,
+		"Populate component inputs in state (true for component providers, false for single-language components)")
 	cmd.Flags().StringArrayVar(&moduleSourceMaps, "module-source-map", nil,
 		"Map module to HCL source path (repeatable, format: module.name=./path)")
 

--- a/pkg/component_metadata.go
+++ b/pkg/component_metadata.go
@@ -1,0 +1,151 @@
+// Copyright 2016-2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pkg
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	hclpkg "github.com/pulumi/pulumi-tool-terraform-migrate/pkg/hcl"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// ComponentSchemaMetadata holds the parsed component interface for each module,
+// written as a sidecar file when --component-inputs=false.
+type ComponentSchemaMetadata struct {
+	Components map[string]ComponentSchema `json:"components"`
+}
+
+// ComponentSchema describes a single component's interface (inputs and outputs).
+type ComponentSchema struct {
+	Type    string               `json:"type"`
+	Source  string               `json:"source,omitempty"`
+	Inputs  []ComponentFieldMeta `json:"inputs"`
+	Outputs []ComponentFieldMeta `json:"outputs"`
+}
+
+// ComponentFieldMeta describes a single input or output field.
+type ComponentFieldMeta struct {
+	Name        string      `json:"name"`
+	Type        string      `json:"type,omitempty"`
+	Required    bool        `json:"required,omitempty"`
+	Default     interface{} `json:"default,omitempty"`
+	Description string      `json:"description,omitempty"`
+}
+
+// buildComponentSchemaMetadata constructs metadata from parsed HCL module definitions.
+func buildComponentSchemaMetadata(
+	components []PulumiResource,
+	componentTree []*componentNode,
+	variables map[string][]hclpkg.ModuleVariable,
+	outputs map[string][]hclpkg.ModuleOutput,
+	sources map[string]string,
+) *ComponentSchemaMetadata {
+	metadata := &ComponentSchemaMetadata{
+		Components: map[string]ComponentSchema{},
+	}
+
+	for _, comp := range components {
+		node := findComponentNode(componentTree, comp.Name)
+		if node == nil {
+			continue
+		}
+		moduleKey := "module." + node.name
+
+		schema := ComponentSchema{
+			Type:   comp.Type,
+			Source: sources[moduleKey],
+		}
+
+		if vars, ok := variables[node.name]; ok {
+			for _, v := range vars {
+				field := ComponentFieldMeta{
+					Name:        v.Name,
+					Type:        v.Type,
+					Required:    v.Default == nil,
+					Description: v.Description,
+				}
+				if v.Default != nil {
+					field.Default = ctyValueToInterface(*v.Default)
+				}
+				schema.Inputs = append(schema.Inputs, field)
+			}
+		}
+
+		if outs, ok := outputs[node.name]; ok {
+			for _, o := range outs {
+				schema.Outputs = append(schema.Outputs, ComponentFieldMeta{
+					Name:        o.Name,
+					Description: o.Description,
+				})
+			}
+		}
+
+		metadata.Components[moduleKey] = schema
+	}
+
+	return metadata
+}
+
+// ctyValueToInterface converts a cty.Value to a plain Go interface{} for JSON serialization.
+func ctyValueToInterface(v cty.Value) interface{} {
+	if v.IsNull() || !v.IsKnown() {
+		return nil
+	}
+	ty := v.Type()
+	switch {
+	case ty == cty.String:
+		return v.AsString()
+	case ty == cty.Bool:
+		return v.True()
+	case ty == cty.Number:
+		bf := v.AsBigFloat()
+		if bf.IsInt() {
+			i, _ := bf.Int64()
+			return i
+		}
+		f, _ := bf.Float64()
+		return f
+	case ty.IsListType() || ty.IsTupleType() || ty.IsSetType():
+		var result []interface{}
+		for it := v.ElementIterator(); it.Next(); {
+			_, elem := it.Element()
+			result = append(result, ctyValueToInterface(elem))
+		}
+		return result
+	case ty.IsMapType() || ty.IsObjectType():
+		result := map[string]interface{}{}
+		for it := v.ElementIterator(); it.Next(); {
+			key, elem := it.Element()
+			result[key.AsString()] = ctyValueToInterface(elem)
+		}
+		return result
+	default:
+		return nil
+	}
+}
+
+// WriteComponentSchemaMetadata writes the metadata to a JSON file.
+func WriteComponentSchemaMetadata(metadata *ComponentSchemaMetadata, path string) error {
+	bytes, err := json.MarshalIndent(metadata, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling component schema metadata: %w", err)
+	}
+	if err := os.WriteFile(path, bytes, 0o600); err != nil {
+		return fmt.Errorf("writing component schema metadata: %w", err)
+	}
+	return nil
+}

--- a/pkg/component_metadata_test.go
+++ b/pkg/component_metadata_test.go
@@ -1,0 +1,137 @@
+// Copyright 2016-2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pkg
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	hclpkg "github.com/pulumi/pulumi-tool-terraform-migrate/pkg/hcl"
+	"github.com/stretchr/testify/require"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestBuildComponentSchemaMetadata(t *testing.T) {
+	components := []PulumiResource{
+		{PulumiResourceID: PulumiResourceID{Name: "vpc", Type: "terraform:module/vpc:Vpc"}},
+	}
+	tree := []*componentNode{
+		{name: "vpc", resourceName: "vpc", typeToken: "terraform:module/vpc:Vpc"},
+	}
+
+	defaultVal := cty.StringVal("default-vpc")
+	variables := map[string][]hclpkg.ModuleVariable{
+		"vpc": {
+			{Name: "cidr", Type: "string", Description: "The CIDR block"},
+			{Name: "name", Type: "string", Default: &defaultVal, Description: "VPC name"},
+		},
+	}
+	outputs := map[string][]hclpkg.ModuleOutput{
+		"vpc": {
+			{Name: "vpc_id", Description: "The VPC ID"},
+		},
+	}
+	sources := map[string]string{
+		"module.vpc": "./modules/vpc",
+	}
+
+	metadata := buildComponentSchemaMetadata(components, tree, variables, outputs, sources)
+
+	require.Len(t, metadata.Components, 1)
+	schema, ok := metadata.Components["module.vpc"]
+	require.True(t, ok)
+	require.Equal(t, "terraform:module/vpc:Vpc", schema.Type)
+	require.Equal(t, "./modules/vpc", schema.Source)
+
+	// Check inputs
+	require.Len(t, schema.Inputs, 2)
+	cidr := schema.Inputs[0]
+	require.Equal(t, "cidr", cidr.Name)
+	require.Equal(t, "string", cidr.Type)
+	require.True(t, cidr.Required)
+	require.Nil(t, cidr.Default)
+
+	name := schema.Inputs[1]
+	require.Equal(t, "name", name.Name)
+	require.False(t, name.Required)
+	require.Equal(t, "default-vpc", name.Default)
+
+	// Check outputs
+	require.Len(t, schema.Outputs, 1)
+	require.Equal(t, "vpc_id", schema.Outputs[0].Name)
+	require.Equal(t, "The VPC ID", schema.Outputs[0].Description)
+}
+
+func TestWriteComponentSchemaMetadata(t *testing.T) {
+	metadata := &ComponentSchemaMetadata{
+		Components: map[string]ComponentSchema{
+			"module.vpc": {
+				Type:   "terraform:module/vpc:Vpc",
+				Source: "./modules/vpc",
+				Inputs: []ComponentFieldMeta{
+					{Name: "cidr", Type: "string", Required: true},
+				},
+				Outputs: []ComponentFieldMeta{
+					{Name: "vpc_id"},
+				},
+			},
+		},
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "component-schemas.json")
+	err := WriteComponentSchemaMetadata(metadata, path)
+	require.NoError(t, err)
+
+	// Read back and verify
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	var loaded ComponentSchemaMetadata
+	err = json.Unmarshal(data, &loaded)
+	require.NoError(t, err)
+	require.Len(t, loaded.Components, 1)
+
+	schema := loaded.Components["module.vpc"]
+	require.Equal(t, "terraform:module/vpc:Vpc", schema.Type)
+	require.Len(t, schema.Inputs, 1)
+	require.Equal(t, "cidr", schema.Inputs[0].Name)
+	require.True(t, schema.Inputs[0].Required)
+}
+
+func TestCtyValueToInterface(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    cty.Value
+		expected interface{}
+	}{
+		{"string", cty.StringVal("hello"), "hello"},
+		{"bool", cty.True, true},
+		{"int", cty.NumberIntVal(42), int64(42)},
+		{"float", cty.NumberFloatVal(3.14), 3.14},
+		{"null", cty.NullVal(cty.String), nil},
+		{"list", cty.ListVal([]cty.Value{cty.StringVal("a"), cty.StringVal("b")}), []interface{}{"a", "b"}},
+		{"map", cty.MapVal(map[string]cty.Value{"k": cty.StringVal("v")}), map[string]interface{}{"k": "v"}},
+		{"empty_object", cty.EmptyObjectVal, map[string]interface{}{}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ctyValueToInterface(tt.input)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/pkg/component_populate.go
+++ b/pkg/component_populate.go
@@ -16,6 +16,7 @@ package pkg
 
 import (
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 
@@ -28,6 +29,9 @@ import (
 // For each component that has an HCL source path (via sourceOverrides or auto-discovery),
 // it parses the module call site, evaluates argument expressions, and converts to PropertyMap.
 //
+// When populateInputs=false, component inputs are left empty and a ComponentSchemaMetadata
+// is returned instead (for use as a sidecar file by the code generator).
+//
 // If a schema is provided (via schemaOverrides), the parsed interface is validated against it.
 func populateComponentsFromHCL(
 	components []PulumiResource,
@@ -35,9 +39,10 @@ func populateComponentsFromHCL(
 	sourceOverrides map[string]string,
 	schemaOverrides map[string]string,
 	tfSourceDir string,
-) error {
+	populateInputs bool,
+) (*ComponentSchemaMetadata, error) {
 	if tfSourceDir == "" {
-		return nil
+		return nil, nil
 	}
 
 	// Parse module call sites from the root TF source directory
@@ -45,7 +50,7 @@ func populateComponentsFromHCL(
 	if err != nil {
 		// Not fatal — HCL source may not be available
 		fmt.Fprintf(os.Stderr, "Warning: failed to parse module call sites from %s: %v\n", tfSourceDir, err)
-		return nil
+		return nil, nil
 	}
 
 	// Load tfvars for variable resolution
@@ -61,6 +66,11 @@ func populateComponentsFromHCL(
 	for i := range callSites {
 		callSiteMap[callSites[i].Name] = &callSites[i]
 	}
+
+	// Collect parsed variables/outputs for metadata (when populateInputs=false)
+	parsedVariables := map[string][]hclpkg.ModuleVariable{}
+	parsedOutputs := map[string][]hclpkg.ModuleOutput{}
+	resolvedSources := map[string]string{}
 
 	// Process each component
 	for i, comp := range components {
@@ -81,15 +91,23 @@ func populateComponentsFromHCL(
 				sourcePath = filepath.Join(tfSourceDir, callSite.Source)
 			}
 		}
+		if sourcePath != "" {
+			resolvedSources["module."+moduleName] = sourcePath
+		}
 
-		// Populate inputs from call site argument evaluation
+		// Parse module variables (needed for both metadata and default merging)
+		if sourcePath != "" {
+			if vars, err := hclpkg.ParseModuleVariables(sourcePath); err == nil {
+				parsedVariables[moduleName] = vars
+			}
+		}
+
+		// Populate inputs from call site argument evaluation (only when populateInputs=true)
 		callSite, hasCallSite := callSiteMap[moduleName]
-		if hasCallSite && len(callSite.Arguments) > 0 {
+		if populateInputs && hasCallSite && len(callSite.Arguments) > 0 {
 			// Build eval context variables including count.index / each.key
 			evalVars := map[string]cty.Value{}
-			for k, v := range tfvars {
-				evalVars[k] = v
-			}
+			maps.Copy(evalVars, tfvars)
 
 			// Build meta-argument context (count.index, each.key/each.value)
 			var metaVars map[string]cty.Value
@@ -120,6 +138,7 @@ func populateComponentsFromHCL(
 		if sourcePath != "" {
 			outputs, err := hclpkg.ParseModuleOutputs(sourcePath)
 			if err == nil {
+				parsedOutputs[moduleName] = outputs
 				outputMap := resource.PropertyMap{}
 				for _, o := range outputs {
 					// Output values come from TF state (Phase 2 raw state reading),
@@ -138,7 +157,7 @@ func populateComponentsFromHCL(
 			componentType := comp.Type
 			schemaIface, err := LoadComponentSchema(schemaPath, componentType)
 			if err != nil {
-				return fmt.Errorf("loading schema for module.%s: %w", moduleName, err)
+				return nil, fmt.Errorf("loading schema for module.%s: %w", moduleName, err)
 			}
 
 			// Build parsed interface from component's inputs/outputs
@@ -151,12 +170,18 @@ func populateComponentsFromHCL(
 			}
 
 			if err := ValidateAgainstSchema(parsed, schemaIface); err != nil {
-				return fmt.Errorf("schema validation failed for module.%s: %w", moduleName, err)
+				return nil, fmt.Errorf("schema validation failed for module.%s: %w", moduleName, err)
 			}
 		}
 	}
 
-	return nil
+	// Build and return metadata when populateInputs=false
+	if !populateInputs {
+		metadata := buildComponentSchemaMetadata(components, componentTree, parsedVariables, parsedOutputs, resolvedSources)
+		return metadata, nil
+	}
+
+	return nil, nil
 }
 
 // findComponentNode finds the component node by resource name in the tree.
@@ -194,4 +219,3 @@ func buildMetaArgContext(key string) map[string]cty.Value {
 
 	return vars
 }
-

--- a/pkg/pulumi_state.go
+++ b/pkg/pulumi_state.go
@@ -72,9 +72,10 @@ type PulumiResource struct {
 }
 
 type PulumiState struct {
-	Providers  []PulumiResource
-	Components []PulumiResource
-	Resources  []PulumiResource
+	Providers         []PulumiResource
+	Components        []PulumiResource
+	Resources         []PulumiResource
+	ComponentMetadata *ComponentSchemaMetadata
 }
 
 func (st PulumiState) FindProvider(identity PulumiResourceID) (PulumiResource, error) {

--- a/pkg/state_adapter.go
+++ b/pkg/state_adapter.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"maps"
 	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 
@@ -55,6 +56,7 @@ func TranslateAndWriteState(
 	requiredProvidersOutputFilePath string,
 	strict bool,
 	enableComponents bool,
+	populateComponentInputs bool,
 	typeOverrides map[string]string,
 	sourceOverrides map[string]string,
 	schemaOverrides map[string]string,
@@ -98,7 +100,7 @@ func TranslateAndWriteState(
 		}
 	}
 
-	res, err := TranslateState(ctx, tfState, providerVersions.ProviderSelections, stackName, projectName, enableComponents, typeOverrides, sourceOverrides, schemaOverrides, tfDir)
+	res, err := TranslateState(ctx, tfState, providerVersions.ProviderSelections, stackName, projectName, enableComponents, populateComponentInputs, typeOverrides, sourceOverrides, schemaOverrides, tfDir)
 	if err != nil {
 		return err
 	}
@@ -117,6 +119,14 @@ func TranslateAndWriteState(
 	err = os.WriteFile(outputFilePath, bytes, 0o600)
 	if err != nil {
 		return fmt.Errorf("failed to write stack export: %w", err)
+	}
+
+	// Write component schema metadata sidecar file when --component-inputs=false
+	if res.ComponentMetadata != nil {
+		metadataPath := filepath.Join(filepath.Dir(outputFilePath), "component-schemas.json")
+		if err := WriteComponentSchemaMetadata(res.ComponentMetadata, metadataPath); err != nil {
+			return fmt.Errorf("failed to write component schema metadata: %w", err)
+		}
 	}
 
 	if requiredProvidersOutputFilePath != "" {
@@ -144,15 +154,17 @@ type TranslateStateResult struct {
 	Export            StackExport
 	RequiredProviders []*ProviderWithMetadata
 	ErrorMessages     []ErroredResource
+	// ComponentMetadata is non-nil when --component-inputs=false and HCL sources were parsed.
+	ComponentMetadata *ComponentSchemaMetadata
 }
 
-func TranslateState(ctx context.Context, tfState *tfjson.State, providerVersions map[string]string, stackName, projectName string, enableComponents bool, typeOverrides map[string]string, sourceOverrides map[string]string, schemaOverrides map[string]string, tfSourceDir string) (*TranslateStateResult, error) {
+func TranslateState(ctx context.Context, tfState *tfjson.State, providerVersions map[string]string, stackName, projectName string, enableComponents bool, populateComponentInputs bool, typeOverrides map[string]string, sourceOverrides map[string]string, schemaOverrides map[string]string, tfSourceDir string) (*TranslateStateResult, error) {
 	pulumiProviders, err := GetPulumiProvidersForTerraformState(tfState, providerVersions)
 	if err != nil {
 		return nil, err
 	}
 
-	pulumiState, errorMessages, err := convertState(tfState, pulumiProviders, enableComponents, typeOverrides, sourceOverrides, schemaOverrides, tfSourceDir)
+	pulumiState, errorMessages, err := convertState(tfState, pulumiProviders, enableComponents, populateComponentInputs, typeOverrides, sourceOverrides, schemaOverrides, tfSourceDir)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert state: %w", err)
 	}
@@ -171,6 +183,7 @@ func TranslateState(ctx context.Context, tfState *tfjson.State, providerVersions
 		},
 		RequiredProviders: requiredProviders,
 		ErrorMessages:     errorMessages,
+		ComponentMetadata: pulumiState.ComponentMetadata,
 	}, nil
 }
 
@@ -181,7 +194,7 @@ type ErroredResource struct {
 	ErrorMessage     string `json:"error_message"`
 }
 
-func convertState(tfState *tfjson.State, pulumiProviders map[providermap.TerraformProviderName]*ProviderWithMetadata, enableComponents bool, typeOverrides map[string]string, sourceOverrides map[string]string, schemaOverrides map[string]string, tfSourceDir string) (*PulumiState, []ErroredResource, error) {
+func convertState(tfState *tfjson.State, pulumiProviders map[providermap.TerraformProviderName]*ProviderWithMetadata, enableComponents bool, populateComponentInputs bool, typeOverrides map[string]string, sourceOverrides map[string]string, schemaOverrides map[string]string, tfSourceDir string) (*PulumiState, []ErroredResource, error) {
 	pulumiState := &PulumiState{}
 
 	// TODO[pulumi/pulumi-service#35512]: This assumes one Pulumi provider per Terraform provider.
@@ -226,9 +239,11 @@ func convertState(tfState *tfjson.State, pulumiProviders map[providermap.Terrafo
 			pulumiState.Components = toComponents(componentTree, "")
 
 			// Populate component inputs/outputs from HCL when source is available
-			if err := populateComponentsFromHCL(pulumiState.Components, componentTree, sourceOverrides, schemaOverrides, tfSourceDir); err != nil {
+			metadata, err := populateComponentsFromHCL(pulumiState.Components, componentTree, sourceOverrides, schemaOverrides, tfSourceDir, populateComponentInputs)
+			if err != nil {
 				return nil, nil, fmt.Errorf("failed to populate component state from HCL: %w", err)
 			}
+			pulumiState.ComponentMetadata = metadata
 		}
 	}
 

--- a/pkg/state_adapter_test.go
+++ b/pkg/state_adapter_test.go
@@ -88,7 +88,7 @@ func TestConvertTwoModules_FlatMode(t *testing.T) {
 	require.NoError(t, err)
 
 	// enableComponents=false: flat mode, no component resources
-	data, err := TranslateState(ctx, tfState, nil, "dev", "test-project", false, nil, nil, nil, "")
+	data, err := TranslateState(ctx, tfState, nil, "dev", "test-project", false, true, nil, nil, nil, "")
 	require.NoError(t, err)
 
 	// No component resources in flat mode
@@ -214,7 +214,7 @@ func TestConvertWithHCLPopulation(t *testing.T) {
 	require.NoError(t, err)
 
 	// Pass tfSourceDir so HCL parsing populates component inputs
-	data, err := TranslateState(ctx, tfState, nil, "dev", "test-project", true, nil, nil, nil, "testdata/tf_indexed_modules")
+	data, err := TranslateState(ctx, tfState, nil, "dev", "test-project", true, true, nil, nil, nil, "testdata/tf_indexed_modules")
 	require.NoError(t, err)
 
 	// Find component resources
@@ -275,7 +275,7 @@ func TestConvertWithSchemaValidation(t *testing.T) {
 		"module.pet": "testdata/schemas/pet_component_schema.json",
 	}
 
-	data, err := TranslateState(ctx, tfState, nil, "dev", "test-project", true, nil, nil, schemaOverrides, "testdata/tf_indexed_modules")
+	data, err := TranslateState(ctx, tfState, nil, "dev", "test-project", true, true, nil, nil, schemaOverrides, "testdata/tf_indexed_modules")
 	require.NoError(t, err)
 
 	// Find component resources and verify they have populated inputs/outputs
@@ -309,7 +309,7 @@ func TestConvertWithSchemaValidation_CustomTypeToken(t *testing.T) {
 		"module.pet": "testdata/schemas/pet_custom_component_schema.json",
 	}
 
-	data, err := TranslateState(ctx, tfState, nil, "dev", "test-project", true, typeOverrides, nil, schemaOverrides, "testdata/tf_indexed_modules")
+	data, err := TranslateState(ctx, tfState, nil, "dev", "test-project", true, true, typeOverrides, nil, schemaOverrides, "testdata/tf_indexed_modules")
 	require.NoError(t, err)
 
 	var components []apitype.ResourceV3
@@ -341,7 +341,7 @@ func TestConvertWithSchemaValidation_Mismatch(t *testing.T) {
 		"module.pet": "testdata/schemas/pet_component_schema_mismatch.json",
 	}
 
-	_, err = TranslateState(ctx, tfState, nil, "dev", "test-project", true, nil, nil, schemaOverrides, "testdata/tf_indexed_modules")
+	_, err = TranslateState(ctx, tfState, nil, "dev", "test-project", true, true, nil, nil, schemaOverrides, "testdata/tf_indexed_modules")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "region")
 	require.Contains(t, err.Error(), "required by schema")
@@ -354,7 +354,7 @@ func translateStateFromJson(ctx context.Context, tfStateJson string) (*Translate
 	if err != nil {
 		return nil, err
 	}
-	return TranslateState(ctx, tfState, nil, "dev", "test-project", true, nil, nil, nil, "")
+	return TranslateState(ctx, tfState, nil, "dev", "test-project", true, true, nil, nil, nil, "")
 }
 
 func Test_convertState_simple(t *testing.T) {
@@ -369,7 +369,7 @@ func Test_convertState_simple(t *testing.T) {
 	pulumiProviders, err := GetPulumiProvidersForTerraformState(tfState, nil)
 	require.NoError(t, err, "failed to get Pulumi providers")
 
-	pulumiState, errorMessages, err := convertState(tfState, pulumiProviders, false, nil, nil, nil, "")
+	pulumiState, errorMessages, err := convertState(tfState, pulumiProviders, false, true, nil, nil, nil, "")
 	require.NoError(t, err, "failed to convert state")
 	require.Equal(t, 0, len(errorMessages), "expected no error messages")
 
@@ -396,7 +396,7 @@ func Test_convertState_multi_provider(t *testing.T) {
 	pulumiProviders, err := GetPulumiProvidersForTerraformState(tfState, nil)
 	require.NoError(t, err, "failed to get Pulumi providers")
 
-	pulumiState, errorMessages, err := convertState(tfState, pulumiProviders, false, nil, nil, nil, "")
+	pulumiState, errorMessages, err := convertState(tfState, pulumiProviders, false, true, nil, nil, nil, "")
 	require.NoError(t, err, "failed to convert state")
 	require.Equal(t, 0, len(errorMessages), "expected no error messages")
 
@@ -451,7 +451,7 @@ func Test_convertState_corrupted_state(t *testing.T) {
 	pulumiProviders, err := GetPulumiProvidersForTerraformState(tfState, nil)
 	require.NoError(t, err, "failed to get Pulumi providers")
 
-	_, errorMessages, err := convertState(tfState, pulumiProviders, false, nil, nil, nil, "")
+	_, errorMessages, err := convertState(tfState, pulumiProviders, false, true, nil, nil, nil, "")
 	require.NoError(t, err, "failed to convert state")
 	require.Equal(t, 1, len(errorMessages), "expected 1 error message")
 	require.Equal(t, "password", errorMessages[0].ResourceName)
@@ -474,7 +474,7 @@ func Test_convertState_unknown_provider(t *testing.T) {
 
 	require.Len(t, pulumiProviders, 1, "should only have 1 provider (random)")
 
-	pulumiState, errorMessages, err := convertState(tfState, pulumiProviders, false, nil, nil, nil, "")
+	pulumiState, errorMessages, err := convertState(tfState, pulumiProviders, false, true, nil, nil, nil, "")
 	require.NoError(t, err, "failed to convert state")
 
 	require.Len(t, errorMessages, 1, "expected 1 error message for unknown_resource")

--- a/test/translate_test.go
+++ b/test/translate_test.go
@@ -101,7 +101,7 @@ func TestTranslateBasic(t *testing.T) {
 
 	ctx := context.Background()
 
-	err := pkg.TranslateAndWriteState(ctx, statePath, stackFolder, filepath.Join(stackFolder, "state.json"), "", false, true, nil, nil, nil, "", "")
+	err := pkg.TranslateAndWriteState(ctx, statePath, stackFolder, filepath.Join(stackFolder, "state.json"), "", false, true, true, nil, nil, nil, "", "")
 	require.NoError(t, err)
 
 	_ = runCommand(t, stackFolder, "pulumi", "stack", "import", "--file", filepath.Join(stackFolder, "state.json"))
@@ -135,7 +135,7 @@ func TestTranslateBasicWithDependencies(t *testing.T) {
 	statePath := setupTFStack(t, "testdata/tf_random_stack")
 	stackFolder, _ := createPulumiStack(t)
 
-	err := pkg.TranslateAndWriteState(ctx, statePath, stackFolder, filepath.Join(stackFolder, "state.json"), filepath.Join(stackFolder, "dependencies.json"), false, true, nil, nil, nil, "", "")
+	err := pkg.TranslateAndWriteState(ctx, statePath, stackFolder, filepath.Join(stackFolder, "state.json"), filepath.Join(stackFolder, "dependencies.json"), false, true, true, nil, nil, nil, "", "")
 	require.NoError(t, err)
 
 	dependencies, err := os.ReadFile(filepath.Join(stackFolder, "dependencies.json"))
@@ -151,7 +151,7 @@ func TestTranslateBasicWithEdit(t *testing.T) {
 	statePath := setupTFStack(t, "testdata/tf_random_stack")
 	stackFolder, stackName := createPulumiStack(t)
 
-	err := pkg.TranslateAndWriteState(ctx, statePath, stackFolder, filepath.Join(stackFolder, "state.json"), "", false, true, nil, nil, nil, "", "")
+	err := pkg.TranslateAndWriteState(ctx, statePath, stackFolder, filepath.Join(stackFolder, "state.json"), "", false, true, true, nil, nil, nil, "", "")
 	require.NoError(t, err)
 
 	_ = runCommand(t, stackFolder, "pulumi", "stack", "import", "--file", filepath.Join(stackFolder, "state.json"))
@@ -209,7 +209,7 @@ func TestTranslateWithDependency(t *testing.T) {
 	statePath := setupTFStack(t, "testdata/tf_dependency_stack")
 	stackFolder, stackName := createPulumiStack(t)
 
-	err := pkg.TranslateAndWriteState(ctx, statePath, stackFolder, filepath.Join(stackFolder, "state.json"), "", false, true, nil, nil, nil, "", "")
+	err := pkg.TranslateAndWriteState(ctx, statePath, stackFolder, filepath.Join(stackFolder, "state.json"), "", false, true, true, nil, nil, nil, "", "")
 	require.NoError(t, err)
 
 	_ = runCommand(t, stackFolder, "pulumi", "stack", "import", "--file", filepath.Join(stackFolder, "state.json"))


### PR DESCRIPTION
**Design & Plan:** [`feat/module-to-component-design`](https://github.com/pulumi/pulumi-tool-terraform-migrate/tree/feat/module-to-component-design) ([spec](https://github.com/pulumi/pulumi-tool-terraform-migrate/blob/feat/module-to-component-design/docs/superpowers/specs/2026-03-31-module-to-component-design.md) · [plan](https://github.com/pulumi/pulumi-tool-terraform-migrate/blob/feat/module-to-component-design/docs/superpowers/plans/2026-03-31-module-to-component.md))

When --component-inputs=true (default), component inputs are populated
in translated state from HCL call-site evaluation. Use for component
providers / IDP registration.

When --component-inputs=false, component inputs are left empty and a
component-schemas.json sidecar file is written alongside the state
output. Use for single-language ComponentResource classes where SDKs
historically send empty inputs.

Outputs are always populated regardless of the flag.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>