### PR TITLE
feat/mc-17-root-var-defaults

### DIFF
--- a/pkg/component_populate.go
+++ b/pkg/component_populate.go
@@ -65,6 +65,15 @@ func populateComponentsFromHCL(
 		tfvars = map[string]cty.Value{}
 	}
 
+	// Merge root variable defaults into tfvars (tfvars take precedence).
+	// This ensures locals that reference var.* with defaults can evaluate.
+	rootVars, _ := hclpkg.ParseModuleVariables(tfSourceDir)
+	for _, v := range rootVars {
+		if _, alreadySet := tfvars[v.Name]; !alreadySet && v.Default != nil {
+			tfvars[v.Name] = *v.Default
+		}
+	}
+
 	// Resolve remote module sources from .terraform/modules/ cache
 	cachedModuleSources, _ := hclpkg.ResolveModuleSourcesFromCache(tfSourceDir)
 


### PR DESCRIPTION
**Design & Plan:** [`feat/module-to-component-design`](https://github.com/pulumi/pulumi-tool-terraform-migrate/tree/feat/module-to-component-design) ([plan](https://github.com/pulumi/pulumi-tool-terraform-migrate/blob/feat/module-to-component-design/docs/superpowers/plans/2026-04-03-remaining-eval-gaps.md))

Root variable blocks with defaults (e.g., variable "environment" {
default = "dev" }) weren't in the eval context, causing root locals
that reference them to fail. Parse root variables and merge defaults
into tfvars (tfvars take precedence) before locals evaluation.

Fixes ~22 warnings for local.* refs like local.common_tags, local.name.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>