### PR TITLE
feat/mc-18-indexed-resource-refs

### DIFF
--- a/pkg/component_populate.go
+++ b/pkg/component_populate.go
@@ -249,6 +249,10 @@ func populateComponentsFromHCL(
 
 				evaluateAndAddLocals(sourcePath, outputEvalCtx)
 
+				// Register missing resource types as empty tuples so conditional
+				// resources (count=0) resolve to [] instead of "Unknown variable".
+				registerMissingResourceTypes(sourcePath, moduleResourceAttrs, outputEvalCtx, moduleName)
+
 				outputMap := resource.PropertyMap{}
 				for _, o := range outputs {
 					if o.Expression != nil {
@@ -431,6 +435,30 @@ func buildScopedResourceAttrMap(tfState *tfjson.State) scopedResourceAttrs {
 		return nil
 	}, &tofu.VisitOptions{})
 
+	// Post-process: for indexed resources (this[0], this[1], this["key"]),
+	// create a base name entry (this) as a tuple/object so HCL expressions
+	// like resource.this[0].attr resolve correctly.
+	for _, typeMap := range result {
+		for _, instances := range typeMap {
+			grouped := map[string][]cty.Value{} // baseName → [instance0, instance1, ...]
+			for name, val := range instances {
+				if idx := strings.Index(name, "["); idx > 0 {
+					baseName := name[:idx]
+					grouped[baseName] = append(grouped[baseName], val)
+				}
+			}
+			for baseName, vals := range grouped {
+				if _, exists := instances[baseName]; !exists {
+					if len(vals) == 1 {
+						instances[baseName] = vals[0]
+					} else {
+						instances[baseName] = cty.TupleVal(vals)
+					}
+				}
+			}
+		}
+	}
+
 	return result
 }
 
@@ -495,6 +523,35 @@ func parseCallSitesCached(dir string, cache map[string]map[string]*hclpkg.Module
 	}
 	cache[dir] = result
 	return result
+}
+
+// registerMissingResourceTypes scans the module HCL source for resource blocks and
+// registers any resource types not in the scoped attr map as empty tuple values.
+// This handles conditional resources (count=0) that don't exist in state.
+func registerMissingResourceTypes(
+	sourcePath string,
+	moduleResourceAttrs map[string]map[string]cty.Value,
+	evalCtx *hclpkg.EvalContext,
+	moduleName string,
+) {
+	resourceTypes, err := hclpkg.ParseResourceTypeNames(sourcePath)
+	if err != nil {
+		return
+	}
+	missingTypes := map[string]cty.Value{}
+	for _, resType := range resourceTypes {
+		if moduleResourceAttrs != nil {
+			if _, ok := moduleResourceAttrs[resType]; ok {
+				continue // already in scoped attrs
+			}
+		}
+		// Resource type not in state — register as empty object with empty instances
+		fmt.Fprintf(os.Stderr, "Note: resource type %s not in state for module.%s (likely count=0), defaulting to empty\n", resType, moduleName)
+		missingTypes[resType] = cty.EmptyObjectVal
+	}
+	if len(missingTypes) > 0 {
+		evalCtx.AddVariables(missingTypes)
+	}
 }
 
 // parseResourceAddress splits a TF resource address into module path, type, and name.

--- a/pkg/hcl/parser.go
+++ b/pkg/hcl/parser.go
@@ -27,6 +27,33 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
+// ParseResourceTypeNames extracts unique resource type names from .tf files in a directory.
+func ParseResourceTypeNames(dir string) ([]string, error) {
+	files, err := parseTFFiles(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	seen := map[string]bool{}
+	for _, f := range files {
+		body, ok := f.Body.(*hclsyntax.Body)
+		if !ok {
+			continue
+		}
+		for _, block := range body.Blocks {
+			if block.Type == "resource" && len(block.Labels) >= 1 {
+				seen[block.Labels[0]] = true
+			}
+		}
+	}
+
+	var types []string
+	for t := range seen {
+		types = append(types, t)
+	}
+	return types, nil
+}
+
 // ModuleVariable represents a parsed variable block from a Terraform module.
 type ModuleVariable struct {
 	Name        string


### PR DESCRIPTION
**Design & Plan:** [`feat/module-to-component-design`](https://github.com/pulumi/pulumi-tool-terraform-migrate/tree/feat/module-to-component-design) ([plan](https://github.com/pulumi/pulumi-tool-terraform-migrate/blob/feat/module-to-component-design/docs/superpowers/plans/2026-04-03-remaining-eval-gaps.md))

- Group indexed resource instances (this[0], this[1]) under base name
  (this) as a tuple in scoped attrs. Enables HCL expressions like
  aws_acm_certificate.this[0].arn to resolve.
- Register missing resource types (conditional, count=0) as empty
  objects in the output eval context. Logs a note explaining the
  resource is not in state rather than a confusing "Unknown variable".
- Add ParseResourceTypeNames to extract resource types from HCL source.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>