### PR TITLE
feat/mc-19-conditional-resource-defaults

### DIFF
--- a/pkg/component_populate.go
+++ b/pkg/component_populate.go
@@ -245,7 +245,11 @@ func populateComponentsFromHCL(
 					moduleVars = hclpkg.PulumiPropertyMapToCtyMap(components[i].Inputs)
 				}
 
-				outputEvalCtx := hclpkg.NewEvalContext(moduleVars, moduleResourceAttrs, nil)
+				// Build child module output cross-refs for parent modules
+			// (e.g., rdsdb needs module.db_instance.* outputs to evaluate its own outputs)
+			childOutputs := buildChildModuleOutputs(node, componentTree, moduleOutputValues)
+
+			outputEvalCtx := hclpkg.NewEvalContext(moduleVars, moduleResourceAttrs, childOutputs)
 
 				evaluateAndAddLocals(sourcePath, outputEvalCtx)
 
@@ -525,32 +529,88 @@ func parseCallSitesCached(dir string, cache map[string]map[string]*hclpkg.Module
 	return result
 }
 
+// buildChildModuleOutputs collects resolved outputs from child components of a given node.
+// For a parent module like "rdsdb" with children "db_instance", "db_option_group", etc.,
+// this returns {"db_instance": {output1: val1, ...}, "db_option_group": {...}}.
+func buildChildModuleOutputs(
+	node *componentNode,
+	tree []*componentNode,
+	moduleOutputValues map[string]map[string]cty.Value,
+) map[string]map[string]cty.Value {
+	if node.children == nil {
+		return nil
+	}
+	result := map[string]map[string]cty.Value{}
+	for _, child := range node.children {
+		if outputs, ok := moduleOutputValues[child.name]; ok {
+			result[child.name] = outputs
+		}
+	}
+	if len(result) == 0 {
+		return nil
+	}
+	return result
+}
+
 // registerMissingResourceTypes scans the module HCL source for resource blocks and
-// registers any resource types not in the scoped attr map as empty tuple values.
+// registers any not in the scoped attr map with empty default values.
 // This handles conditional resources (count=0) that don't exist in state.
+// Registers as: type = {name = []} so expressions like aws_ebs_volume.this[0] resolve.
 func registerMissingResourceTypes(
 	sourcePath string,
 	moduleResourceAttrs map[string]map[string]cty.Value,
 	evalCtx *hclpkg.EvalContext,
 	moduleName string,
 ) {
-	resourceTypes, err := hclpkg.ParseResourceTypeNames(sourcePath)
+	resourceBlocks, err := hclpkg.ParseResourceBlocks(sourcePath)
 	if err != nil {
 		return
 	}
-	missingTypes := map[string]cty.Value{}
-	for _, resType := range resourceTypes {
+
+	// Group by type, collect instance names
+	typeInstances := map[string]map[string]bool{} // type → set of names
+	for _, rb := range resourceBlocks {
 		if moduleResourceAttrs != nil {
-			if _, ok := moduleResourceAttrs[resType]; ok {
-				continue // already in scoped attrs
+			if instances, ok := moduleResourceAttrs[rb.Type]; ok {
+				if _, hasName := instances[rb.Name]; hasName {
+					continue // this specific instance exists in state
+				}
 			}
 		}
-		// Resource type not in state — register as empty object with empty instances
-		fmt.Fprintf(os.Stderr, "Note: resource type %s not in state for module.%s (likely count=0), defaulting to empty\n", resType, moduleName)
-		missingTypes[resType] = cty.EmptyObjectVal
+		if _, ok := typeInstances[rb.Type]; !ok {
+			typeInstances[rb.Type] = map[string]bool{}
+		}
+		typeInstances[rb.Type][rb.Name] = true
 	}
-	if len(missingTypes) > 0 {
-		evalCtx.AddVariables(missingTypes)
+
+	missingVars := map[string]cty.Value{}
+	for resType, names := range typeInstances {
+		instances := map[string]cty.Value{}
+
+		// Keep existing instances from state
+		if moduleResourceAttrs != nil {
+			if existing, ok := moduleResourceAttrs[resType]; ok {
+				for k, v := range existing {
+					instances[k] = v
+				}
+			}
+		}
+
+		// Add missing instances as empty tuples
+		for name := range names {
+			if _, exists := instances[name]; !exists {
+				fmt.Fprintf(os.Stderr, "Note: %s.%s not in state for module.%s (likely count=0), defaulting to empty\n", resType, name, moduleName)
+				instances[name] = cty.EmptyTupleVal
+			}
+		}
+
+		if len(instances) > 0 {
+			missingVars[resType] = cty.ObjectVal(instances)
+		}
+	}
+
+	if len(missingVars) > 0 {
+		evalCtx.AddVariables(missingVars)
 	}
 }
 
@@ -633,20 +693,19 @@ func findComponentNode(tree []*componentNode, resourceName string) *componentNod
 func buildMetaArgContext(key string) map[string]cty.Value {
 	vars := map[string]cty.Value{}
 
-	// Try parsing as integer (count index)
+	// Set both count and each — we can't always distinguish count from for_each
+	// (e.g., for_each = toset(["0", "1"]) uses numeric-looking string keys).
+	// Setting both is safe since TF expressions only reference one or the other.
 	var idx int
 	if _, err := fmt.Sscanf(key, "%d", &idx); err == nil {
-		// count-based: count = { index = N }
 		vars["count"] = cty.ObjectVal(map[string]cty.Value{
 			"index": cty.NumberIntVal(int64(idx)),
 		})
-	} else {
-		// for_each-based: each = { key = "K", value = "K" }
-		vars["each"] = cty.ObjectVal(map[string]cty.Value{
-			"key":   cty.StringVal(key),
-			"value": cty.StringVal(key),
-		})
 	}
+	vars["each"] = cty.ObjectVal(map[string]cty.Value{
+		"key":   cty.StringVal(key),
+		"value": cty.StringVal(key),
+	})
 
 	return vars
 }

--- a/pkg/component_populate.go
+++ b/pkg/component_populate.go
@@ -596,11 +596,15 @@ func registerMissingResourceTypes(
 			}
 		}
 
-		// Add missing instances as empty tuples
+		// Add missing instances using the attribute shape of existing instances.
+		// Construct an object with the same attributes as a real instance, but
+		// all values set to null strings. This lets expressions like
+		// aws_resource.this.id resolve to "" instead of panicking.
+		template := buildNullAttributeTemplate(instances)
 		for name := range names {
 			if _, exists := instances[name]; !exists {
-				fmt.Fprintf(os.Stderr, "Note: %s.%s not in state for module.%s (likely count=0), defaulting to empty\n", resType, name, moduleName)
-				instances[name] = cty.EmptyTupleVal
+				fmt.Fprintf(os.Stderr, "Note: %s.%s not in state for module.%s (likely count=0), defaulting to null\n", resType, name, moduleName)
+				instances[name] = template
 			}
 		}
 
@@ -612,6 +616,26 @@ func registerMissingResourceTypes(
 	if len(missingVars) > 0 {
 		evalCtx.AddVariables(missingVars)
 	}
+}
+
+// buildNullAttributeTemplate creates a cty object with the same attribute names as
+// existing instances but all values set to null strings. Used for missing resource
+// instances (count=0) so attribute access resolves to "" instead of panicking.
+func buildNullAttributeTemplate(instances map[string]cty.Value) cty.Value {
+	// Find any existing instance to use as a template
+	for _, inst := range instances {
+		if inst.Type().IsObjectType() {
+			nullAttrs := map[string]cty.Value{}
+			for name := range inst.Type().AttributeTypes() {
+				nullAttrs[name] = cty.StringVal("")
+			}
+			if len(nullAttrs) > 0 {
+				return cty.ObjectVal(nullAttrs)
+			}
+		}
+		break
+	}
+	return cty.EmptyObjectVal
 }
 
 // parseResourceAddress splits a TF resource address into module path, type, and name.

--- a/pkg/component_populate_test.go
+++ b/pkg/component_populate_test.go
@@ -290,6 +290,71 @@ func TestScopedResourceAttrs_ForModule(t *testing.T) {
 	require.Nil(t, root)
 }
 
+func TestBuildNullAttributeTemplate(t *testing.T) {
+	// When existing instances have attributes, template should have same attrs with "" values
+	instances := map[string]cty.Value{
+		"this[0]": cty.ObjectVal(map[string]cty.Value{
+			"id":     cty.StringVal("subnet-123"),
+			"arn":    cty.StringVal("arn:aws:..."),
+			"vpc_id": cty.StringVal("vpc-456"),
+		}),
+	}
+	template := buildNullAttributeTemplate(instances)
+	require.True(t, template.Type().IsObjectType())
+	require.Equal(t, cty.StringVal(""), template.GetAttr("id"))
+	require.Equal(t, cty.StringVal(""), template.GetAttr("arn"))
+	require.Equal(t, cty.StringVal(""), template.GetAttr("vpc_id"))
+}
+
+func TestBuildNullAttributeTemplate_NoInstances(t *testing.T) {
+	template := buildNullAttributeTemplate(map[string]cty.Value{})
+	require.True(t, template.RawEquals(cty.EmptyObjectVal))
+}
+
+func TestBuildChildModuleOutputs(t *testing.T) {
+	parent := &componentNode{
+		name:         "rdsdb",
+		resourceName: "rdsdb",
+		children: []*componentNode{
+			{name: "db_instance", resourceName: "db_instance"},
+			{name: "db_subnet_group", resourceName: "db_subnet_group"},
+		},
+	}
+	tree := []*componentNode{parent}
+
+	moduleOutputValues := map[string]map[string]cty.Value{
+		"db_instance":     {"address": cty.StringVal("mydb.rds.amazonaws.com")},
+		"db_subnet_group": {"id": cty.StringVal("sg-123")},
+	}
+
+	childOutputs := buildChildModuleOutputs(parent, tree, moduleOutputValues)
+	require.NotNil(t, childOutputs)
+	require.Len(t, childOutputs, 2)
+	require.Equal(t, cty.StringVal("mydb.rds.amazonaws.com"), childOutputs["db_instance"]["address"])
+	require.Equal(t, cty.StringVal("sg-123"), childOutputs["db_subnet_group"]["id"])
+}
+
+func TestBuildChildModuleOutputs_NoChildren(t *testing.T) {
+	node := &componentNode{name: "vpc", resourceName: "vpc"}
+	result := buildChildModuleOutputs(node, nil, nil)
+	require.Nil(t, result)
+}
+
+func TestBuildMetaArgContext_AlwaysSetsEach(t *testing.T) {
+	// Numeric keys should set BOTH count and each
+	vars := buildMetaArgContext("0")
+	require.Contains(t, vars, "count")
+	require.Contains(t, vars, "each")
+	require.Equal(t, cty.StringVal("0"), vars["each"].GetAttr("key"))
+
+	// String keys should set each (and no count)
+	vars2 := buildMetaArgContext("us-east-1")
+	_, hasCount := vars2["count"]
+	require.False(t, hasCount)
+	require.Contains(t, vars2, "each")
+	require.Equal(t, cty.StringVal("us-east-1"), vars2["each"].GetAttr("key"))
+}
+
 func TestInterfaceToCty(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/pkg/hcl/evaluator.go
+++ b/pkg/hcl/evaluator.go
@@ -72,7 +72,16 @@ func (e *EvalContext) AddVariables(vars map[string]cty.Value) {
 }
 
 // EvaluateExpression evaluates an HCL expression against the context.
-func (e *EvalContext) EvaluateExpression(expr hcl.Expression) (cty.Value, error) {
+// Includes panic recovery because the upstream HCL library can panic on
+// certain type combinations in conditional expressions (e.g., DynamicPseudoType
+// branches from null resource defaults).
+func (e *EvalContext) EvaluateExpression(expr hcl.Expression) (val cty.Value, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			val = cty.NilVal
+			err = fmt.Errorf("expression evaluation panicked (upstream HCL bug): %v", r)
+		}
+	}()
 	val, diags := expr.Value(e.hclCtx)
 	if diags.HasErrors() {
 		return cty.NilVal, fmt.Errorf("expression evaluation failed: %s", diags.Error())

--- a/pkg/hcl/parser.go
+++ b/pkg/hcl/parser.go
@@ -27,13 +27,20 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
-// ParseResourceTypeNames extracts unique resource type names from .tf files in a directory.
-func ParseResourceTypeNames(dir string) ([]string, error) {
+// ResourceBlock represents a resource type and name from a resource block declaration.
+type ResourceBlock struct {
+	Type string // e.g., "aws_vpc"
+	Name string // e.g., "this"
+}
+
+// ParseResourceBlocks extracts resource type+name pairs from .tf files in a directory.
+func ParseResourceBlocks(dir string) ([]ResourceBlock, error) {
 	files, err := parseTFFiles(dir)
 	if err != nil {
 		return nil, err
 	}
 
+	var blocks []ResourceBlock
 	seen := map[string]bool{}
 	for _, f := range files {
 		body, ok := f.Body.(*hclsyntax.Body)
@@ -41,17 +48,16 @@ func ParseResourceTypeNames(dir string) ([]string, error) {
 			continue
 		}
 		for _, block := range body.Blocks {
-			if block.Type == "resource" && len(block.Labels) >= 1 {
-				seen[block.Labels[0]] = true
+			if block.Type == "resource" && len(block.Labels) >= 2 {
+				key := block.Labels[0] + "." + block.Labels[1]
+				if !seen[key] {
+					seen[key] = true
+					blocks = append(blocks, ResourceBlock{Type: block.Labels[0], Name: block.Labels[1]})
+				}
 			}
 		}
 	}
-
-	var types []string
-	for t := range seen {
-		types = append(types, t)
-	}
-	return types, nil
+	return blocks, nil
 }
 
 // ModuleVariable represents a parsed variable block from a Terraform module.

--- a/pkg/hcl/parser_test.go
+++ b/pkg/hcl/parser_test.go
@@ -158,6 +158,25 @@ func TestParseLocals_NoLocals(t *testing.T) {
 	require.Len(t, locals, 0)
 }
 
+func TestParseResourceBlocks(t *testing.T) {
+	t.Parallel()
+	blocks, err := ParseResourceBlocks("testdata/pet_module")
+	require.NoError(t, err)
+	require.Len(t, blocks, 1)
+	require.Equal(t, "random_pet", blocks[0].Type)
+	require.Equal(t, "this", blocks[0].Name)
+}
+
+func TestParseResourceBlocks_MultipleTypes(t *testing.T) {
+	// root_with_resource_ref has random_pet.base + module (no other resources in root)
+	t.Parallel()
+	blocks, err := ParseResourceBlocks("testdata/root_with_resource_ref")
+	require.NoError(t, err)
+	require.Len(t, blocks, 1)
+	require.Equal(t, "random_pet", blocks[0].Type)
+	require.Equal(t, "base", blocks[0].Name)
+}
+
 func findCall(calls []ModuleCallSite, name string) *ModuleCallSite {
 	for i := range calls {
 		if calls[i].Name == name {


### PR DESCRIPTION
Three fixes:

1. Better empty defaults for conditional resources: register missing
   resource instances by name (e.g., aws_ebs_volume.this = []) instead
   of just the type as an empty object. Fixes "Unsupported attribute
   this" warnings.

2. Nested module cross-refs: build child module output namespace for
   parent module output evaluation. Fixes rdsdb outputs that reference
   module.db_instance.* submodule outputs.

3. Always set both count.index AND each.key/each.value in meta-arg
   context. Fixes for_each modules with numeric string keys like
   toset(["0", "1"]) where the key was misidentified as count index.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>