### PR TITLE
feat/mc-21-remaining-eval-gaps

### DIFF
--- a/pkg/component_populate.go
+++ b/pkg/component_populate.go
@@ -91,8 +91,13 @@ func populateComponentsFromHCL(
 
 	// Pre-pass: resolve source paths and evaluate module outputs for cross-references.
 	// This builds the module.* namespace so input expressions like module.vpc.vpc_id resolve.
+	// Two phases: (1) resolve sources and evaluate leaf modules, (2) evaluate parent modules
+	// with child outputs available.
 	moduleOutputValues := map[string]map[string]cty.Value{}
 	resolvedSources := map[string]string{}
+
+	// Phase 1: resolve all source paths and evaluate leaf module outputs
+	var parentNodes []*componentNode
 	for _, comp := range components {
 		node := findComponentNode(componentTree, comp.Name)
 		if node == nil {
@@ -104,27 +109,49 @@ func populateComponentsFromHCL(
 		}
 		resolvedSources["module."+node.name] = sourcePath
 
-		outputs, err := hclpkg.ParseModuleOutputs(sourcePath)
-		if err != nil || len(outputs) == 0 {
+		// Defer parent modules (those with children) to phase 2
+		if len(node.children) > 0 {
+			parentNodes = append(parentNodes, node)
 			continue
 		}
-		moduleResourceAttrs := scopedAttrs.forModule(node.modulePath)
-		outputEvalCtx := hclpkg.NewEvalContext(nil, moduleResourceAttrs, nil)
 
-		evaluateAndAddLocals(sourcePath, outputEvalCtx)
+		evaluatePrePassOutputs(node, sourcePath, scopedAttrs, nil, moduleOutputValues)
+	}
 
-		evaluated := map[string]cty.Value{}
-		for _, o := range outputs {
-			if o.Expression != nil {
-				val, evalErr := outputEvalCtx.EvaluateExpression(o.Expression)
-				if evalErr == nil {
-					evaluated[o.Name] = val
-				}
+	// Resolve child module source paths from parent directories so
+	// buildChildModuleOutputs can find them in phase 2.
+	for _, parentNode := range parentNodes {
+		parentSource := resolvedSources["module."+parentNode.name]
+		if parentSource == "" {
+			continue
+		}
+		parentCallSites, _ := hclpkg.ParseModuleCallSites(parentSource)
+		for _, cs := range parentCallSites {
+			childKey := "module." + cs.Name
+			if _, already := resolvedSources[childKey]; already {
+				continue
+			}
+			if hclpkg.IsLocalModuleSource(cs.Source) {
+				resolvedSources[childKey] = filepath.Join(parentSource, cs.Source)
 			}
 		}
-		if len(evaluated) > 0 {
-			moduleOutputValues[node.name] = evaluated
+		// Also evaluate any child nodes that weren't resolved from root call sites
+		for _, child := range parentNode.children {
+			if _, already := moduleOutputValues[child.name]; already {
+				continue
+			}
+			childSource := resolvedSources["module."+child.name]
+			if childSource != "" {
+				evaluatePrePassOutputs(child, childSource, scopedAttrs, nil, moduleOutputValues)
+			}
 		}
+	}
+
+	// Phase 2: evaluate parent module outputs with child outputs available
+	for _, node := range parentNodes {
+		sourcePath := resolvedSources["module."+node.name]
+		childOutputs := buildChildModuleOutputs(node, moduleOutputValues, resolvedSources, cachedModuleSources)
+		evaluatePrePassOutputs(node, sourcePath, scopedAttrs, childOutputs, moduleOutputValues)
 	}
 
 	// Cache parsed call sites per directory (root already parsed)
@@ -191,6 +218,17 @@ func populateComponentsFromHCL(
 						if _, alreadySet := evalVars[v.Name]; !alreadySet && v.Default != nil {
 							evalVars[v.Name] = *v.Default
 						}
+					}
+				}
+				// Convert null-typed defaults to zero values so functions like
+				// coalesce() don't reject mixed null/concrete types.
+				// Also convert cty.NilVal (Go zero-value from PropertyMap round-trip)
+				// to empty string, since NilVal panics on .IsNull()/.Type().
+				for k, v := range evalVars {
+					if v == cty.NilVal {
+						evalVars[k] = cty.StringVal("")
+					} else if v.IsNull() {
+						evalVars[k] = ctyNullToZero(v)
 					}
 				}
 			} else {
@@ -278,16 +316,16 @@ func populateComponentsFromHCL(
 				}
 
 				// Build child module output cross-refs for parent modules
-			// (e.g., rdsdb needs module.db_instance.* outputs to evaluate its own outputs)
-			childOutputs := buildChildModuleOutputs(node, moduleOutputValues, resolvedSources, cachedModuleSources)
+				// (e.g., rdsdb needs module.db_instance.* outputs to evaluate its own outputs)
+				childOutputs := buildChildModuleOutputs(node, moduleOutputValues, resolvedSources, cachedModuleSources)
 
-			outputEvalCtx := hclpkg.NewEvalContext(moduleVars, moduleResourceAttrs, childOutputs)
+				outputEvalCtx := hclpkg.NewEvalContext(moduleVars, moduleResourceAttrs, childOutputs)
+
+				// Register missing resource types BEFORE locals evaluation so
+				// locals referencing conditional resources (count=0) resolve.
+				registerMissingResourceTypes(sourcePath, moduleResourceAttrs, outputEvalCtx, moduleName)
 
 				evaluateAndAddLocals(sourcePath, outputEvalCtx)
-
-				// Register missing resource types as empty tuples so conditional
-				// resources (count=0) resolve to [] instead of "Unknown variable".
-				registerMissingResourceTypes(sourcePath, moduleResourceAttrs, outputEvalCtx, moduleName)
 
 				outputMap := resource.PropertyMap{}
 				for _, o := range outputs {
@@ -398,6 +436,57 @@ func evaluateAndAddLocals(sourcePath string, evalCtx *hclpkg.EvalContext) {
 		return
 	}
 	evalCtx.AddVariables(map[string]cty.Value{"local": cty.ObjectVal(vals)})
+}
+
+// ctyNullToZero converts a cty.NullVal to the zero value for its type.
+// This prevents type mismatch errors in functions like coalesce() that
+// reject mixed null/concrete types.
+func ctyNullToZero(v cty.Value) cty.Value {
+	ty := v.Type()
+	switch {
+	case ty == cty.String:
+		return cty.StringVal("")
+	case ty == cty.Number:
+		return cty.NumberIntVal(0)
+	case ty == cty.Bool:
+		return cty.BoolVal(false)
+	case ty == cty.DynamicPseudoType:
+		// HCL parses "default = null" without type context as DynamicPseudoType.
+		// Default to empty string since most Terraform variables are strings.
+		return cty.StringVal("")
+	default:
+		return v // leave complex types as-is
+	}
+}
+
+func evaluatePrePassOutputs(
+	node *componentNode,
+	sourcePath string,
+	scopedAttrs scopedResourceAttrs,
+	childOutputs map[string]map[string]cty.Value,
+	moduleOutputValues map[string]map[string]cty.Value,
+) {
+	outputs, err := hclpkg.ParseModuleOutputs(sourcePath)
+	if err != nil || len(outputs) == 0 {
+		return
+	}
+	moduleResourceAttrs := scopedAttrs.forModule(node.modulePath)
+	outputEvalCtx := hclpkg.NewEvalContext(nil, moduleResourceAttrs, childOutputs)
+
+	evaluateAndAddLocals(sourcePath, outputEvalCtx)
+
+	evaluated := map[string]cty.Value{}
+	for _, o := range outputs {
+		if o.Expression != nil {
+			val, evalErr := outputEvalCtx.EvaluateExpression(o.Expression)
+			if evalErr == nil {
+				evaluated[o.Name] = val
+			}
+		}
+	}
+	if len(evaluated) > 0 {
+		moduleOutputValues[node.name] = evaluated
+	}
 }
 
 // buildDataSourceAttrMap builds a nested cty.Value for the "data" eval context variable.
@@ -638,8 +727,12 @@ func registerMissingResourceTypes(
 		return
 	}
 
-	// Group by type, collect instance names
-	typeInstances := map[string]map[string]bool{} // type → set of names
+	// Group by type, collect instance names and track count/for_each
+	type missingResource struct {
+		hasCount   bool
+		hasForEach bool
+	}
+	typeInstances := map[string]map[string]missingResource{} // type → name → info
 	for _, rb := range resourceBlocks {
 		if moduleResourceAttrs != nil {
 			if instances, ok := moduleResourceAttrs[rb.Type]; ok {
@@ -649,9 +742,12 @@ func registerMissingResourceTypes(
 			}
 		}
 		if _, ok := typeInstances[rb.Type]; !ok {
-			typeInstances[rb.Type] = map[string]bool{}
+			typeInstances[rb.Type] = map[string]missingResource{}
 		}
-		typeInstances[rb.Type][rb.Name] = true
+		typeInstances[rb.Type][rb.Name] = missingResource{
+			hasCount:   rb.HasCount,
+			hasForEach: rb.HasForEach,
+		}
 	}
 
 	missingVars := map[string]cty.Value{}
@@ -667,20 +763,23 @@ func registerMissingResourceTypes(
 			}
 		}
 
-		// Add missing instances using the attribute shape of existing instances.
-		// Construct an object with the same attributes as a real instance, but
-		// all values set to null strings. This lets expressions like
-		// aws_resource.this.id resolve to "" instead of panicking.
-		// Pick any missing name to use for HCL-based attribute discovery
 		var sampleName string
 		for name := range names {
 			sampleName = name
 			break
 		}
 		template := buildNullAttributeTemplate(instances, sourcePath, resType, sampleName)
-		for name := range names {
-			if _, exists := instances[name]; !exists {
-				fmt.Fprintf(os.Stderr, "Note: %s.%s not in state for module.%s (likely count=0), defaulting to null\n", resType, name, moduleName)
+		for name, info := range names {
+			if _, exists := instances[name]; exists {
+				continue
+			}
+			fmt.Fprintf(os.Stderr, "Note: %s.%s not in state for module.%s (likely count=0), defaulting to null\n", resType, name, moduleName)
+			// Resources with count or for_each that have zero instances in state
+			// should be registered as empty tuples so splat/for-each resolve to [].
+			// Resources without count/for_each use the template for .attr access.
+			if info.hasCount || info.hasForEach {
+				instances[name] = cty.EmptyTupleVal
+			} else {
 				instances[name] = template
 			}
 		}

--- a/pkg/component_populate_test.go
+++ b/pkg/component_populate_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"testing"
 
+	hclpkg "github.com/pulumi/pulumi-tool-terraform-migrate/pkg/hcl"
 	"github.com/pulumi/pulumi-tool-terraform-migrate/pkg/tofu"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/stretchr/testify/require"
@@ -475,6 +476,126 @@ func TestInterfaceToCty(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := interfaceToCty(tt.input)
+			require.True(t, result.RawEquals(tt.expected), "got %s, want %s", result.GoString(), tt.expected.GoString())
+		})
+	}
+}
+
+func TestPopulateComponentsFromHCL_PrePassChildModuleOutputs(t *testing.T) {
+	// Parent module has: output "child_val" { value = module.child.val }
+	// Child module has: output "val" { value = "hello-from-child" }
+	// Consumer module has: input name = module.parent.child_val
+	//
+	// Without the pre-pass building child module outputs for parent modules,
+	// module.parent.child_val won't resolve, so consumer's input "name" will be missing.
+	components := []PulumiResource{
+		{PulumiResourceID: PulumiResourceID{Name: "parent", Type: "terraform:module/parent:Parent"}},
+		{PulumiResourceID: PulumiResourceID{Name: "child", Type: "terraform:module/child:Child"}},
+		{PulumiResourceID: PulumiResourceID{Name: "consumer", Type: "terraform:module/consumer:Consumer"}},
+	}
+	tree := []*componentNode{
+		{
+			name: "parent", resourceName: "parent", typeToken: "terraform:module/parent:Parent",
+			modulePath: "module.parent",
+			children: []*componentNode{
+				{name: "child", resourceName: "child", typeToken: "terraform:module/child:Child",
+					modulePath: "module.parent.module.child"},
+			},
+		},
+		{name: "consumer", resourceName: "consumer", typeToken: "terraform:module/consumer:Consumer",
+			modulePath: "module.consumer"},
+	}
+
+	_, err := populateComponentsFromHCL(
+		components, tree, nil, nil,
+		"hcl/testdata/root_with_parent_child_output", true, nil, nil,
+	)
+	require.NoError(t, err)
+
+	// Consumer's input "name" should be "hello-from-child" — resolved through
+	// parent's output which references child's output via module.child.val
+	consumerInputs := components[2].Inputs
+	require.NotNil(t, consumerInputs, "consumer should have inputs resolved from module.parent.child_val")
+	require.Contains(t, consumerInputs, resource.PropertyKey("name"))
+	require.Equal(t, resource.NewStringProperty("hello-from-child"), consumerInputs["name"])
+}
+
+func TestPopulateComponentsFromHCL_NullDefaultsConvertedToZeroValues(t *testing.T) {
+	// When a parent module variable has a null default (default = null with type = string),
+	// and a nested child call site passes that var, coalesce(var.x, var.y) should not
+	// fail because of null type mismatch. The null should be converted to "" for strings.
+	//
+	// Fixture: parent has var.optional_name (default=null, type=string) and var.fallback_name (default="fallback")
+	//          child call: name = coalesce(var.optional_name, var.fallback_name)
+	components := []PulumiResource{
+		{PulumiResourceID: PulumiResourceID{Name: "parent", Type: "terraform:module/parent:Parent"}},
+		{PulumiResourceID: PulumiResourceID{Name: "child", Type: "terraform:module/child:Child"}},
+	}
+	tree := []*componentNode{
+		{
+			name: "parent", resourceName: "parent", typeToken: "terraform:module/parent:Parent",
+			modulePath: "module.parent",
+			children: []*componentNode{
+				{name: "child", resourceName: "child", typeToken: "terraform:module/child:Child",
+					modulePath: "module.parent.module.child"},
+			},
+		},
+	}
+
+	_, err := populateComponentsFromHCL(
+		components, tree, nil, nil,
+		"hcl/testdata/root_with_coalesce_null", true, nil, nil,
+	)
+	require.NoError(t, err)
+
+	// Child should get name="fallback" — coalesce("", "fallback") = "fallback"
+	// (null default was converted to "" so coalesce doesn't reject mixed types)
+	childInputs := components[1].Inputs
+	require.NotNil(t, childInputs, "child should have inputs resolved through coalesce")
+	require.Contains(t, childInputs, resource.PropertyKey("name"))
+	require.Equal(t, resource.NewStringProperty("fallback"), childInputs["name"])
+}
+
+func TestRegisterMissingResourceTypes_AllMissingAsEmptyTuple(t *testing.T) {
+	// When ALL instances of a resource type+name are missing from state,
+	// registerMissingResourceTypes should register them as cty.EmptyTupleVal
+	// so splat expressions and for-each iterate over an empty collection.
+
+	// sourcePath with resource block "aws_route_table_association" "redshift" (count=0)
+	// and output using splat: aws_route_table_association.redshift[*].id
+	sourcePath := "hcl/testdata/resource_with_count"
+
+	moduleResourceAttrs := map[string]map[string]cty.Value{} // nothing in state
+	evalCtx := hclpkg.NewEvalContext(nil, moduleResourceAttrs, nil)
+
+	registerMissingResourceTypes(sourcePath, moduleResourceAttrs, evalCtx, "vpc")
+
+	// Verify by evaluating the output that uses a splat on the missing resource.
+	// If registered as EmptyTupleVal, the splat resolves to [].
+	outputs, err := hclpkg.ParseModuleOutputs(sourcePath)
+	require.NoError(t, err)
+	require.Len(t, outputs, 1)
+
+	val, evalErr := evalCtx.EvaluateExpression(outputs[0].Expression)
+	require.NoError(t, evalErr, "splat on zero-instance resource should not error")
+	require.True(t, val.Type().IsTupleType(), "splat result should be a tuple")
+	require.Equal(t, 0, val.LengthInt(), "splat on zero-instance resource should be empty")
+}
+
+func TestCtyNullToZero(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    cty.Value
+		expected cty.Value
+	}{
+		{"null_string", cty.NullVal(cty.String), cty.StringVal("")},
+		{"null_number", cty.NullVal(cty.Number), cty.NumberIntVal(0)},
+		{"null_bool", cty.NullVal(cty.Bool), cty.BoolVal(false)},
+		{"null_dynamic", cty.NullVal(cty.DynamicPseudoType), cty.StringVal("")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ctyNullToZero(tt.input)
 			require.True(t, result.RawEquals(tt.expected), "got %s, want %s", result.GoString(), tt.expected.GoString())
 		})
 	}

--- a/pkg/hcl/evaluator.go
+++ b/pkg/hcl/evaluator.go
@@ -16,6 +16,7 @@ package hcl
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/pulumi/opentofu/lang"
@@ -78,6 +79,7 @@ func (e *EvalContext) AddVariables(vars map[string]cty.Value) {
 func (e *EvalContext) EvaluateExpression(expr hcl.Expression) (val cty.Value, err error) {
 	defer func() {
 		if r := recover(); r != nil {
+			fmt.Fprintf(os.Stderr, "Debug: HCL expression evaluation panicked: %v\n", r)
 			val = cty.NilVal
 			err = fmt.Errorf("expression evaluation panicked (upstream HCL bug): %v", r)
 		}

--- a/pkg/hcl/parser.go
+++ b/pkg/hcl/parser.go
@@ -29,8 +29,10 @@ import (
 
 // ResourceBlock represents a resource type and name from a resource block declaration.
 type ResourceBlock struct {
-	Type string // e.g., "aws_vpc"
-	Name string // e.g., "this"
+	Type        string // e.g., "aws_vpc"
+	Name        string // e.g., "this"
+	HasCount    bool   // resource has count meta-argument
+	HasForEach  bool   // resource has for_each meta-argument
 }
 
 // ParseResourceBlocks extracts resource type+name pairs from .tf files in a directory.
@@ -52,7 +54,12 @@ func ParseResourceBlocks(dir string) ([]ResourceBlock, error) {
 				key := block.Labels[0] + "." + block.Labels[1]
 				if !seen[key] {
 					seen[key] = true
-					blocks = append(blocks, ResourceBlock{Type: block.Labels[0], Name: block.Labels[1]})
+					rb := ResourceBlock{Type: block.Labels[0], Name: block.Labels[1]}
+					if block.Body != nil {
+						_, rb.HasCount = block.Body.Attributes["count"]
+						_, rb.HasForEach = block.Body.Attributes["for_each"]
+					}
+					blocks = append(blocks, rb)
 				}
 			}
 		}

--- a/pkg/hcl/testdata/resource_with_count/main.tf
+++ b/pkg/hcl/testdata/resource_with_count/main.tf
@@ -1,0 +1,9 @@
+resource "aws_route_table_association" "redshift" {
+  count          = 0
+  subnet_id      = "subnet-xxx"
+  route_table_id = "rtb-xxx"
+}
+
+output "redshift_route_table_association_ids" {
+  value = aws_route_table_association.redshift[*].id
+}

--- a/pkg/hcl/testdata/root_with_coalesce_null/main.tf
+++ b/pkg/hcl/testdata/root_with_coalesce_null/main.tf
@@ -1,0 +1,3 @@
+module "parent" {
+  source = "./modules/parent"
+}

--- a/pkg/hcl/testdata/root_with_coalesce_null/modules/child/main.tf
+++ b/pkg/hcl/testdata/root_with_coalesce_null/modules/child/main.tf
@@ -1,0 +1,2 @@
+variable "name" { type = string }
+output "received" { value = var.name }

--- a/pkg/hcl/testdata/root_with_coalesce_null/modules/parent/main.tf
+++ b/pkg/hcl/testdata/root_with_coalesce_null/modules/parent/main.tf
@@ -1,0 +1,12 @@
+variable "optional_name" {
+  type    = string
+  default = null
+}
+variable "fallback_name" {
+  type    = string
+  default = "fallback"
+}
+module "child" {
+  source = "../child"
+  name   = coalesce(var.optional_name, var.fallback_name)
+}

--- a/pkg/hcl/testdata/root_with_parent_child_output/main.tf
+++ b/pkg/hcl/testdata/root_with_parent_child_output/main.tf
@@ -1,0 +1,7 @@
+module "parent" {
+  source = "./modules/parent"
+}
+module "consumer" {
+  source = "./modules/consumer"
+  name   = module.parent.child_val
+}

--- a/pkg/hcl/testdata/root_with_parent_child_output/modules/child/main.tf
+++ b/pkg/hcl/testdata/root_with_parent_child_output/modules/child/main.tf
@@ -1,0 +1,1 @@
+output "val" { value = "hello-from-child" }

--- a/pkg/hcl/testdata/root_with_parent_child_output/modules/consumer/main.tf
+++ b/pkg/hcl/testdata/root_with_parent_child_output/modules/consumer/main.tf
@@ -1,0 +1,2 @@
+variable "name" { type = string }
+output "received" { value = var.name }

--- a/pkg/hcl/testdata/root_with_parent_child_output/modules/parent/main.tf
+++ b/pkg/hcl/testdata/root_with_parent_child_output/modules/parent/main.tf
@@ -1,0 +1,4 @@
+module "child" {
+  source = "../child"
+}
+output "child_val" { value = module.child.val }


### PR DESCRIPTION
- Add two-phase pre-pass: evaluate leaf modules first, then parents with
  child outputs available (fixes module output cross-ref warnings)
- Convert null-typed variable defaults to zero values for nested call
  sites so coalesce() doesn't reject mixed null/concrete types
- Register zero-instance resources (count/for_each) as EmptyTupleVal
  instead of template objects so splat/for-each resolve to []
- Move registerMissingResourceTypes before locals evaluation so locals
  referencing conditional resources can resolve
- Log panics in HCL expression evaluator for debugging
- Add HasCount/HasForEach to ResourceBlock for smarter registration
- DNS-to-DB eval warnings: 68 → 12 → 2 (only templatefile remains)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>