### PR TITLE
feat/mc-23-remove-null-defaults

### DIFF
--- a/pkg/component_populate.go
+++ b/pkg/component_populate.go
@@ -281,14 +281,6 @@ func populateComponentsFromHCL(
 				}
 				inputs[resource.PropertyKey(argName)] = hclpkg.CtyValueToPulumiPropertyValue(val)
 			}
-			// Merge variable defaults for any variable not already in call-site args
-			if vars, ok := parsedVariables[moduleName]; ok {
-				for _, v := range vars {
-					if _, alreadySet := inputs[resource.PropertyKey(v.Name)]; !alreadySet && v.Default != nil {
-						inputs[resource.PropertyKey(v.Name)] = hclpkg.CtyValueToPulumiPropertyValue(*v.Default)
-					}
-				}
-			}
 
 			if len(inputs) > 0 {
 				components[i].Inputs = inputs
@@ -313,6 +305,15 @@ func populateComponentsFromHCL(
 				moduleVars := map[string]cty.Value{}
 				if components[i].Inputs != nil {
 					moduleVars = hclpkg.PulumiPropertyMapToCtyMap(components[i].Inputs)
+				}
+				// Include variable defaults in the eval context (but not in state inputs)
+				// so that output expressions referencing unset variables can still resolve.
+				if vars, ok := parsedVariables[moduleName]; ok {
+					for _, v := range vars {
+						if _, alreadySet := moduleVars[v.Name]; !alreadySet && v.Default != nil {
+							moduleVars[v.Name] = *v.Default
+						}
+					}
 				}
 
 				// Build child module output cross-refs for parent modules

--- a/pkg/component_populate_test.go
+++ b/pkg/component_populate_test.go
@@ -52,8 +52,9 @@ func TestPopulateComponentsFromHCL_VariableDefaults(t *testing.T) {
 	require.Equal(t, resource.NewNumberProperty(3), inputs["length"])
 }
 
-func TestPopulateComponentsFromHCL_VariableDefaultsMerged(t *testing.T) {
-	// Use "pet" module call which only passes prefix — defaults for separator and length should merge.
+func TestPopulateComponentsFromHCL_VariableDefaultsNotMerged(t *testing.T) {
+	// Use "pet" module call which only passes prefix — defaults for separator and length
+	// should NOT be merged into state (they belong in component-schemas.json only).
 	// pet has count=2 so we test with pet-0 instance.
 	components := []PulumiResource{
 		{PulumiResourceID: PulumiResourceID{Name: "pet-0", Type: "terraform:module/pet:Pet"}},
@@ -73,13 +74,12 @@ func TestPopulateComponentsFromHCL_VariableDefaultsMerged(t *testing.T) {
 	require.Contains(t, inputs, resource.PropertyKey("prefix"))
 	require.Equal(t, resource.NewStringProperty("test-0"), inputs["prefix"])
 
-	// separator was NOT in call site, default is "-"
-	require.Contains(t, inputs, resource.PropertyKey("separator"))
-	require.Equal(t, resource.NewStringProperty("-"), inputs["separator"])
+	// separator and length were NOT in call site — they should NOT appear in state
+	require.NotContains(t, inputs, resource.PropertyKey("separator"))
+	require.NotContains(t, inputs, resource.PropertyKey("length"))
 
-	// length was NOT in call site, default is 2
-	require.Contains(t, inputs, resource.PropertyKey("length"))
-	require.Equal(t, resource.NewNumberProperty(2), inputs["length"])
+	// Only 1 input (prefix) should be present
+	require.Len(t, inputs, 1)
 }
 
 func TestPopulateComponentsFromHCL_NoInputsWhenFlagFalse(t *testing.T) {

--- a/pkg/e2e_test.go
+++ b/pkg/e2e_test.go
@@ -513,11 +513,12 @@ func TestConvertTfvarsResolution(t *testing.T) {
 	require.GreaterOrEqual(t, len(components), 1, "should have at least 1 component")
 
 	// Component inputs should have prefix="staging" (from tfvars env="staging")
-	// and suffix="prod" (from variable default)
+	// suffix="prod" is a variable default — should NOT be in state (belongs in component-schemas.json)
 	comp := components[0]
 	require.NotNil(t, comp.Inputs, "component inputs should not be nil")
 	require.Equal(t, "staging", comp.Inputs["prefix"], "prefix should be 'staging' from tfvars")
-	require.Equal(t, "prod", comp.Inputs["suffix"], "suffix should be 'prod' from variable default")
+	_, hasSuffix := comp.Inputs["suffix"]
+	require.False(t, hasSuffix, "variable defaults should not be in state")
 }
 
 // --- Special key sanitization (Fixture 6) ---


### PR DESCRIPTION
Variable defaults (including null defaults) were being merged into
component state inputs, inflating input counts (e.g., VPC: 222 → 17,
ACM: 20 → 6). State should only contain call-site arguments; defaults
belong in component-schemas.json. Variable defaults are still added to
the output eval context so output expressions can resolve var.* refs.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>