### PR TITLE
feat/mc-24-templatefile-basedir

### DIFF
--- a/pkg/component_populate.go
+++ b/pkg/component_populate.go
@@ -240,17 +240,19 @@ func populateComponentsFromHCL(
 				metaVars = buildMetaArgContext(node.key)
 			}
 
-			evalCtx := hclpkg.NewEvalContext(evalVars, resourceAttrs, moduleOutputValues)
+			absSourceDir, _ := filepath.Abs(tfSourceDir)
+			evalCtx := hclpkg.NewEvalContext(evalVars, resourceAttrs, moduleOutputValues, tfSourceDir)
 			if metaVars != nil {
 				evalCtx.AddVariables(metaVars)
 			}
 
-			// Add path.* refs
+			// Add path.* refs using absolute paths so file()/templatefile()
+			// produce absolute paths that aren't double-prefixed by BaseDir.
 			evalCtx.AddVariables(map[string]cty.Value{
 				"path": cty.ObjectVal(map[string]cty.Value{
-					"module": cty.StringVal(tfSourceDir),
-					"root":   cty.StringVal(tfSourceDir),
-					"cwd":    cty.StringVal(tfSourceDir),
+					"module": cty.StringVal(absSourceDir),
+					"root":   cty.StringVal(absSourceDir),
+					"cwd":    cty.StringVal(absSourceDir),
 				}),
 			})
 
@@ -320,7 +322,7 @@ func populateComponentsFromHCL(
 				// (e.g., rdsdb needs module.db_instance.* outputs to evaluate its own outputs)
 				childOutputs := buildChildModuleOutputs(node, moduleOutputValues, resolvedSources, cachedModuleSources)
 
-				outputEvalCtx := hclpkg.NewEvalContext(moduleVars, moduleResourceAttrs, childOutputs)
+				outputEvalCtx := hclpkg.NewEvalContext(moduleVars, moduleResourceAttrs, childOutputs, sourcePath)
 
 				// Register missing resource types BEFORE locals evaluation so
 				// locals referencing conditional resources (count=0) resolve.
@@ -478,7 +480,7 @@ func evaluatePrePassOutputs(
 		return
 	}
 	moduleResourceAttrs := scopedAttrs.forModule(node.modulePath)
-	outputEvalCtx := hclpkg.NewEvalContext(nil, moduleResourceAttrs, childOutputs)
+	outputEvalCtx := hclpkg.NewEvalContext(nil, moduleResourceAttrs, childOutputs, sourcePath)
 
 	evaluateAndAddLocals(sourcePath, outputEvalCtx)
 

--- a/pkg/e2e_test.go
+++ b/pkg/e2e_test.go
@@ -151,8 +151,8 @@ func TestConvertDnsToDb_EvalWarningCount(t *testing.T) {
 	for i, w := range warnings {
 		t.Logf("  [%d] %s", i+1, w)
 	}
-	// Was 68 → 12 → 2 (only templatefile missing file warnings remain).
-	require.Less(t, len(warnings), 5, "eval warning count regressed (was 68, now 2; only templatefile warnings remain)")
+	// Was 68 → 12 → 2 → 0 (fixed by resolving file/templatefile paths relative to source dir).
+	require.Equal(t, 0, len(warnings), "eval warning count regressed")
 }
 
 func TestConvertDnsToDb(t *testing.T) {

--- a/pkg/hcl/evaluator.go
+++ b/pkg/hcl/evaluator.go
@@ -40,10 +40,15 @@ func NewEvalContext(
 	variables map[string]cty.Value,
 	resources map[string]map[string]cty.Value,
 	moduleOutputs map[string]map[string]cty.Value,
+	baseDir ...string,
 ) *EvalContext {
+	dir := "."
+	if len(baseDir) > 0 && baseDir[0] != "" {
+		dir = baseDir[0]
+	}
 	ctx := &hcl.EvalContext{
 		Variables: map[string]cty.Value{},
-		Functions: buildFunctionTable(),
+		Functions: buildFunctionTable(dir),
 	}
 
 	if len(variables) > 0 {
@@ -93,7 +98,7 @@ func (e *EvalContext) EvaluateExpression(expr hcl.Expression) (val cty.Value, er
 
 // buildFunctionTable returns the full Terraform-compatible function table
 // using opentofu/lang.Scope which provides all standard + Terraform-specific functions.
-func buildFunctionTable() map[string]function.Function {
-	scope := &lang.Scope{BaseDir: ".", ConsoleMode: true}
+func buildFunctionTable(baseDir string) map[string]function.Function {
+	scope := &lang.Scope{BaseDir: baseDir, ConsoleMode: true}
 	return scope.Functions()
 }


### PR DESCRIPTION
The HCL function table was hardcoded to BaseDir="." which caused
templatefile() and file() to fail when the tool was invoked from a
directory other than the Terraform source root. Thread the source
directory through to lang.Scope.BaseDir and use absolute path.module
refs to avoid double-prefixing.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>