### PR TITLE
feat: replace component-in-state with flat state + component-map.json sidecar

### DIFF
--- a/cmd/stack.go
+++ b/cmd/stack.go
@@ -16,7 +16,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/pulumi/pulumi-tool-terraform-migrate/pkg"
@@ -29,13 +28,11 @@ func newStackCmd() *cobra.Command {
 	var to string
 	var plugins string
 	var strict bool
-	var noModuleComponents bool
 	var moduleTypeMaps []string
 	var pulumiStack string
 	var pulumiProject string
 	var moduleSchemas []string
 	var stateFile string
-	var componentInputs bool
 	var moduleSourceMaps []string
 
 	cmd := &cobra.Command{
@@ -105,13 +102,7 @@ See also:
 				sourceOverrides[parts[0]] = parts[1]
 			}
 
-			enableComponents := !noModuleComponents
-			if noModuleComponents && len(moduleTypeMaps) > 0 {
-				fmt.Fprintf(os.Stderr, "Warning: --module-type-map is ignored when --no-module-components is set\n")
-				typeOverrides = nil
-			}
-
-			err := pkg.TranslateAndWriteState(cmd.Context(), from, stateFile, to, out, plugins, strict, enableComponents, componentInputs, typeOverrides, sourceOverrides, schemaOverrides, pulumiStack, pulumiProject)
+			err := pkg.TranslateAndWriteState(cmd.Context(), from, stateFile, to, out, plugins, strict, typeOverrides, sourceOverrides, schemaOverrides, pulumiStack, pulumiProject)
 			if err != nil {
 				return fmt.Errorf("failed to convert and write Terraform state: %w", err)
 			}
@@ -124,16 +115,12 @@ See also:
 	cmd.Flags().StringVarP(&out, "out", "o", "", "Where to emit the translated Pulumi stack file")
 	cmd.Flags().StringVarP(&plugins, "plugins", "p", "", "Where to emit plugin requirements")
 	cmd.Flags().BoolVarP(&strict, "strict", "s", false, "Fail if any resources fail to be translated")
-	cmd.Flags().BoolVar(&noModuleComponents, "no-module-components", false,
-		"Disable creation of component resources for Terraform modules (flat mode)")
 	cmd.Flags().StringArrayVar(&moduleTypeMaps, "module-type-map", nil,
 		"Override component type token for a module (repeatable, format: module.name=pkg:mod:Type)")
 	cmd.Flags().StringVar(&pulumiStack, "pulumi-stack", "", "Override Pulumi stack name (skip auto-detection)")
 	cmd.Flags().StringVar(&pulumiProject, "pulumi-project", "", "Override Pulumi project name (skip auto-detection)")
 	cmd.Flags().StringArrayVar(&moduleSchemas, "module-schema", nil,
 		"Pulumi package schema for component validation (repeatable, format: module.name=./path/to/schema.json)")
-	cmd.Flags().BoolVar(&componentInputs, "component-inputs", true,
-		"Populate component inputs in state (true for component providers, false for single-language components)")
 	cmd.Flags().StringVar(&stateFile, "state-file", "",
 		"Path to a pre-captured state file (tofu show -json output or terraform.tfstate). Bypasses running tofu commands.")
 	cmd.Flags().StringArrayVar(&moduleSourceMaps, "module-source-map", nil,

--- a/pkg/component_map.go
+++ b/pkg/component_map.go
@@ -38,7 +38,6 @@ type ComponentMap struct {
 type ModuleMapEntry struct {
 	TerraformPath string                       `json:"terraformPath"`
 	Source        string                       `json:"source,omitempty"`
-	SuggestedType string                       `json:"suggestedType"`
 	IndexKey      string                       `json:"indexKey,omitempty"`
 	IndexType     string                       `json:"indexType,omitempty"`
 	Resources     map[string]*ResourceMapEntry `json:"resources"`
@@ -56,9 +55,8 @@ type ResourceMapEntry struct {
 
 // ResourceInstance describes a single instance of a resource within a module.
 type ResourceInstance struct {
-	FlatName  string `json:"flatName"`
-	ShortName string `json:"shortName"`
-	IndexKey  string `json:"indexKey,omitempty"`
+	FlatName string `json:"flatName"`
+	IndexKey string `json:"indexKey,omitempty"`
 }
 
 // ModuleInterface describes the inputs and outputs of a component.
@@ -136,7 +134,6 @@ func buildModuleMapEntry(
 ) *ModuleMapEntry {
 	entry := &ModuleMapEntry{
 		TerraformPath: node.modulePath,
-		SuggestedType: node.typeToken,
 		Resources:     map[string]*ResourceMapEntry{},
 		Modules:       map[string]*ModuleMapEntry{},
 	}
@@ -191,9 +188,8 @@ func buildModuleMapEntry(
 		indexKey := extractResourceIndexKey(res.Address, res.Type, res.Name)
 
 		existing.Instances = append(existing.Instances, ResourceInstance{
-			FlatName:  PulumiNameFromTerraformAddress(res.Address, res.Type),
-			ShortName: shortResourceName(res.Address, res.Type),
-			IndexKey:  indexKey,
+			FlatName: PulumiNameFromTerraformAddress(res.Address, res.Type),
+			IndexKey: indexKey,
 		})
 	}
 
@@ -327,18 +323,6 @@ func WriteComponentMap(cm *ComponentMap, path string) error {
 		return fmt.Errorf("writing component map: %w", err)
 	}
 	return nil
-}
-
-// shortResourceName extracts only the resource name part (after the type) from a Terraform address.
-// Example: "module.vpc.aws_subnet.this" with type "aws_subnet" returns "this".
-func shortResourceName(address, resourceType string) string {
-	parts := strings.Split(address, ".")
-	for i := 0; i < len(parts); i++ {
-		if parts[i] == resourceType {
-			return strings.Join(parts[i+1:], "_")
-		}
-	}
-	return address
 }
 
 // extractResourceIndexKey extracts the instance index key from a fully qualified

--- a/pkg/component_map.go
+++ b/pkg/component_map.go
@@ -36,28 +36,13 @@ type ComponentMap struct {
 
 // ModuleMapEntry describes a single TF module instance mapped to a Pulumi component.
 type ModuleMapEntry struct {
-	TerraformPath string                       `json:"terraformPath"`
-	Source        string                       `json:"source,omitempty"`
-	IndexKey      string                       `json:"indexKey,omitempty"`
-	IndexType     string                       `json:"indexType,omitempty"`
-	Resources     map[string]*ResourceMapEntry `json:"resources"`
-	Interface     *ModuleInterface             `json:"interface,omitempty"`
-	Modules       map[string]*ModuleMapEntry   `json:"modules"`
-}
-
-// ResourceMapEntry describes a resource type within a module.
-// A single type.name in TF (e.g. aws_lb_listener.this) may have multiple
-// instances (via count or for_each), each with its own flat-state name.
-type ResourceMapEntry struct {
-	PulumiType string              `json:"pulumiType"`
-	Instances  []ResourceInstance  `json:"instances"`
-}
-
-// ResourceInstance describes a single instance of a resource within a module.
-type ResourceInstance struct {
-	URN      string `json:"urn"`
-	FlatName string `json:"flatName"`
-	IndexKey string `json:"indexKey,omitempty"`
+	TerraformPath string                     `json:"terraformPath"`
+	Source        string                     `json:"source,omitempty"`
+	IndexKey      string                     `json:"indexKey,omitempty"`
+	IndexType     string                     `json:"indexType,omitempty"`
+	Resources     []string                   `json:"resources"`
+	Interface     *ModuleInterface           `json:"interface,omitempty"`
+	Modules       map[string]*ModuleMapEntry `json:"modules"`
 }
 
 // ModuleInterface describes the inputs and outputs of a component.
@@ -137,7 +122,6 @@ func buildModuleMapEntry(
 ) *ModuleMapEntry {
 	entry := &ModuleMapEntry{
 		TerraformPath: node.modulePath,
-		Resources:     map[string]*ResourceMapEntry{},
 		Modules:       map[string]*ModuleMapEntry{},
 	}
 
@@ -159,7 +143,7 @@ func buildModuleMapEntry(
 		}
 	}
 
-	// Match resources from state to this module, accumulating instances per type.name
+	// Match resources from state to this module, collecting URNs
 	for _, res := range allResources {
 		segments := parseModuleSegments(res.Address)
 		resModulePath := buildModulePath(segments)
@@ -167,36 +151,18 @@ func buildModuleMapEntry(
 			continue
 		}
 
-		// Build the resource map key: "resourceType.resourceName"
-		resMapKey := res.Type + "." + res.Name
-
-		existing, ok := entry.Resources[resMapKey]
-		if !ok {
-			// Determine PulumiType by looking up the provider
-			pulumiType := ""
-			prov, provOk := pulumiProviders[providermap.TerraformProviderName(res.ProviderName)]
-			if provOk {
-				tok, err := bridge.PulumiTypeToken(res.Type, prov.Provider)
-				if err == nil {
-					pulumiType = string(tok)
-				}
+		pulumiType := ""
+		prov, provOk := pulumiProviders[providermap.TerraformProviderName(res.ProviderName)]
+		if provOk {
+			tok, err := bridge.PulumiTypeToken(res.Type, prov.Provider)
+			if err == nil {
+				pulumiType = string(tok)
 			}
-			existing = &ResourceMapEntry{
-				PulumiType: pulumiType,
-			}
-			entry.Resources[resMapKey] = existing
 		}
 
-		// Extract instance index key from the address
-		indexKey := extractResourceIndexKey(res.Address, res.Type, res.Name)
-
 		flatName := PulumiNameFromTerraformAddress(res.Address, res.Type)
-		urn := fmt.Sprintf("urn:pulumi:%s::%s::%s::%s", stackName, projectName, existing.PulumiType, flatName)
-		existing.Instances = append(existing.Instances, ResourceInstance{
-			URN:      urn,
-			FlatName: flatName,
-			IndexKey: indexKey,
-		})
+		urn := fmt.Sprintf("urn:pulumi:%s::%s::%s::%s", stackName, projectName, pulumiType, flatName)
+		entry.Resources = append(entry.Resources, urn)
 	}
 
 	// Interface from metadata + component evaluated values
@@ -329,29 +295,6 @@ func WriteComponentMap(cm *ComponentMap, path string) error {
 		return fmt.Errorf("writing component map: %w", err)
 	}
 	return nil
-}
-
-// extractResourceIndexKey extracts the instance index key from a fully qualified
-// resource address. For "module.vpc.aws_subnet.public[0]" it returns "0".
-// For "module.alb.aws_lb_listener.this[\"my-https-listener\"]" it returns "my-https-listener".
-// Returns "" if the resource has no index.
-func extractResourceIndexKey(address, resourceType, resourceName string) string {
-	// The resource portion is everything after the module path: "type.name" or "type.name[key]"
-	suffix := resourceType + "." + resourceName
-	idx := strings.LastIndex(address, suffix)
-	if idx == -1 {
-		return ""
-	}
-	after := address[idx+len(suffix):]
-	if !strings.HasPrefix(after, "[") || !strings.HasSuffix(after, "]") {
-		return ""
-	}
-	key := after[1 : len(after)-1]
-	// Strip surrounding quotes if present
-	if len(key) >= 2 && key[0] == '"' && key[len(key)-1] == '"' {
-		key = key[1 : len(key)-1]
-	}
-	return key
 }
 
 // stripModulePrefix removes the module path prefix from a resource address,

--- a/pkg/component_map.go
+++ b/pkg/component_map.go
@@ -1,0 +1,340 @@
+// Copyright 2016-2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pkg
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	tfjson "github.com/hashicorp/terraform-json"
+	"github.com/pulumi/pulumi-tool-terraform-migrate/pkg/bridge"
+	"github.com/pulumi/pulumi-tool-terraform-migrate/pkg/providermap"
+	"github.com/pulumi/pulumi-tool-terraform-migrate/pkg/tofu"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+)
+
+// ComponentMap is the top-level structure written to the component-map.json sidecar file.
+// It describes every TF module instance as a component, including its resources and interface.
+type ComponentMap struct {
+	Modules map[string]*ModuleMapEntry `json:"modules"`
+}
+
+// ModuleMapEntry describes a single TF module instance mapped to a Pulumi component.
+type ModuleMapEntry struct {
+	TerraformPath string                       `json:"terraformPath"`
+	Source        string                       `json:"source,omitempty"`
+	SuggestedType string                       `json:"suggestedType"`
+	IndexKey      string                       `json:"indexKey,omitempty"`
+	IndexType     string                       `json:"indexType,omitempty"`
+	Resources     map[string]*ResourceMapEntry `json:"resources"`
+	Interface     *ModuleInterface             `json:"interface,omitempty"`
+	Modules       map[string]*ModuleMapEntry   `json:"modules"`
+}
+
+// ResourceMapEntry describes a single resource within a module.
+type ResourceMapEntry struct {
+	FlatName   string `json:"flatName"`
+	PulumiType string `json:"pulumiType"`
+	ShortName  string `json:"shortName"`
+}
+
+// ModuleInterface describes the inputs and outputs of a component.
+type ModuleInterface struct {
+	Inputs  []ModuleInterfaceField `json:"inputs"`
+	Outputs []ModuleInterfaceField `json:"outputs"`
+}
+
+// ModuleInterfaceField describes a single input or output field of a component interface.
+type ModuleInterfaceField struct {
+	Name           string      `json:"name"`
+	Type           interface{} `json:"type,omitempty"`
+	Required       bool        `json:"required,omitempty"`
+	Default        interface{} `json:"default,omitempty"`
+	Description    string      `json:"description,omitempty"`
+	Expression     string      `json:"expression,omitempty"`
+	EvaluatedValue interface{} `json:"evaluatedValue,omitempty"`
+}
+
+// ComponentMapData is an intermediate struct used to pass data from convertState
+// to the component map writer.
+type ComponentMapData struct {
+	Tree       []*componentNode
+	Components []PulumiResource
+	Metadata   *ComponentSchemaMetadata
+}
+
+// stateResourceInfo holds the fields from tfjson.StateResource needed for resource matching.
+type stateResourceInfo struct {
+	Address      string
+	Type         string
+	Name         string
+	ProviderName string
+}
+
+// buildComponentMap constructs a ComponentMap from the component tree, TF state, metadata,
+// and provider information.
+func buildComponentMap(
+	tree []*componentNode,
+	tfState *tfjson.State,
+	metadata *ComponentSchemaMetadata,
+	components []PulumiResource,
+	pulumiProviders map[providermap.TerraformProviderName]*ProviderWithMetadata,
+) *ComponentMap {
+	var allResources []stateResourceInfo
+	tofu.VisitResources(tfState, func(r *tfjson.StateResource) error {
+		allResources = append(allResources, stateResourceInfo{
+			Address:      r.Address,
+			Type:         r.Type,
+			Name:         r.Name,
+			ProviderName: r.ProviderName,
+		})
+		return nil
+	}, &tofu.VisitOptions{})
+
+	cm := &ComponentMap{
+		Modules: map[string]*ModuleMapEntry{},
+	}
+
+	for _, node := range tree {
+		key := moduleMapKey(node)
+		cm.Modules[key] = buildModuleMapEntry(node, allResources, metadata, components, pulumiProviders)
+	}
+
+	return cm
+}
+
+// buildModuleMapEntry recursively builds a ModuleMapEntry for a single componentNode.
+func buildModuleMapEntry(
+	node *componentNode,
+	allResources []stateResourceInfo,
+	metadata *ComponentSchemaMetadata,
+	components []PulumiResource,
+	pulumiProviders map[providermap.TerraformProviderName]*ProviderWithMetadata,
+) *ModuleMapEntry {
+	entry := &ModuleMapEntry{
+		TerraformPath: node.modulePath,
+		SuggestedType: node.typeToken,
+		Resources:     map[string]*ResourceMapEntry{},
+		Modules:       map[string]*ModuleMapEntry{},
+	}
+
+	// IndexKey and IndexType
+	if node.key != "" {
+		entry.IndexKey = node.key
+		if _, err := strconv.Atoi(node.key); err == nil {
+			entry.IndexType = "count"
+		} else {
+			entry.IndexType = "for_each"
+		}
+	}
+
+	// Source from metadata
+	if metadata != nil {
+		moduleKey := "module." + node.name
+		if schema, ok := metadata.Components[moduleKey]; ok {
+			entry.Source = schema.Source
+		}
+	}
+
+	// Match resources from state to this module
+	for _, res := range allResources {
+		segments := parseModuleSegments(res.Address)
+		resModulePath := buildModulePath(segments)
+		if resModulePath != node.modulePath {
+			continue
+		}
+
+		// Build the resource map key: "resourceType.resourceName"
+		resMapKey := res.Type + "." + res.Name
+
+		// Determine PulumiType by looking up the provider
+		pulumiType := ""
+		prov, ok := pulumiProviders[providermap.TerraformProviderName(res.ProviderName)]
+		if ok {
+			tok, err := bridge.PulumiTypeToken(res.Type, prov.Provider)
+			if err == nil {
+				pulumiType = string(tok)
+			}
+		}
+
+		entry.Resources[resMapKey] = &ResourceMapEntry{
+			FlatName:   PulumiNameFromTerraformAddress(res.Address, res.Type),
+			PulumiType: pulumiType,
+			ShortName:  shortResourceName(res.Address, res.Type),
+		}
+	}
+
+	// Interface from metadata + component evaluated values
+	if metadata != nil {
+		moduleKey := "module." + node.name
+		if schema, ok := metadata.Components[moduleKey]; ok {
+			iface := &ModuleInterface{}
+
+			// Find the matching component for evaluated values
+			var matchingComp *PulumiResource
+			for i := range components {
+				if components[i].Name == node.resourceName {
+					matchingComp = &components[i]
+					break
+				}
+			}
+
+			// Build inputs
+			for _, field := range schema.Inputs {
+				mif := ModuleInterfaceField{
+					Name:        field.Name,
+					Type:        field.Type,
+					Required:    field.Required,
+					Default:     field.Default,
+					Description: field.Description,
+				}
+				if matchingComp != nil {
+					if val, ok := matchingComp.Inputs[resource.PropertyKey(field.Name)]; ok {
+						mif.EvaluatedValue = propertyValueToInterface(val)
+					}
+				}
+				iface.Inputs = append(iface.Inputs, mif)
+			}
+
+			// Build outputs
+			for _, field := range schema.Outputs {
+				mif := ModuleInterfaceField{
+					Name:        field.Name,
+					Type:        field.Type,
+					Description: field.Description,
+				}
+				if matchingComp != nil {
+					if val, ok := matchingComp.Outputs[resource.PropertyKey(field.Name)]; ok {
+						mif.EvaluatedValue = propertyValueToInterface(val)
+					}
+				}
+				iface.Outputs = append(iface.Outputs, mif)
+			}
+
+			if len(iface.Inputs) > 0 || len(iface.Outputs) > 0 {
+				entry.Interface = iface
+			}
+		}
+	}
+
+	// Recurse into children
+	for _, child := range node.children {
+		key := moduleMapKey(child)
+		entry.Modules[key] = buildModuleMapEntry(child, allResources, metadata, components, pulumiProviders)
+	}
+
+	return entry
+}
+
+// moduleMapKey builds the map key for a componentNode.
+// Non-indexed: "name", indexed: "name[0]" or "name[\"key\"]".
+func moduleMapKey(node *componentNode) string {
+	if node.key == "" {
+		return node.name
+	}
+	return node.name + "[" + formatKey(node.key) + "]"
+}
+
+// propertyValueToInterface converts a Pulumi PropertyValue to a plain Go interface{}
+// suitable for JSON serialization.
+func propertyValueToInterface(v resource.PropertyValue) interface{} {
+	if v.IsNull() {
+		return nil
+	}
+	if v.IsSecret() {
+		// Unwrap secrets to get the underlying value
+		return propertyValueToInterface(v.SecretValue().Element)
+	}
+	if v.IsComputed() {
+		return nil
+	}
+	if v.IsOutput() {
+		ov := v.OutputValue()
+		if ov.Known {
+			return propertyValueToInterface(ov.Element)
+		}
+		return nil
+	}
+	if v.IsBool() {
+		return v.BoolValue()
+	}
+	if v.IsNumber() {
+		return v.NumberValue()
+	}
+	if v.IsString() {
+		return v.StringValue()
+	}
+	if v.IsArray() {
+		arr := v.ArrayValue()
+		result := make([]interface{}, len(arr))
+		for i, elem := range arr {
+			result[i] = propertyValueToInterface(elem)
+		}
+		return result
+	}
+	if v.IsObject() {
+		obj := v.ObjectValue()
+		result := make(map[string]interface{}, len(obj))
+		for k, elem := range obj {
+			result[string(k)] = propertyValueToInterface(elem)
+		}
+		return result
+	}
+	return nil
+}
+
+// WriteComponentMap serializes a ComponentMap to a JSON file.
+func WriteComponentMap(cm *ComponentMap, path string) error {
+	bytes, err := json.MarshalIndent(cm, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling component map: %w", err)
+	}
+	bytes = append(bytes, '\n')
+	if err := os.WriteFile(path, bytes, 0o600); err != nil {
+		return fmt.Errorf("writing component map: %w", err)
+	}
+	return nil
+}
+
+// shortResourceName extracts only the resource name part (after the type) from a Terraform address.
+// Example: "module.vpc.aws_subnet.this" with type "aws_subnet" returns "this".
+func shortResourceName(address, resourceType string) string {
+	parts := strings.Split(address, ".")
+	for i := 0; i < len(parts); i++ {
+		if parts[i] == resourceType {
+			return strings.Join(parts[i+1:], "_")
+		}
+	}
+	return address
+}
+
+// stripModulePrefix removes the module path prefix from a resource address,
+// returning just the "resourceType.resourceName" portion.
+func stripModulePrefix(address string) string {
+	parts := splitAddressParts(address)
+	// Skip all "module.xxx" segments
+	i := 0
+	for i < len(parts) {
+		if parts[i] == "module" && i+1 < len(parts) {
+			i += 2
+		} else {
+			break
+		}
+	}
+	return strings.Join(parts[i:], ".")
+}

--- a/pkg/component_map.go
+++ b/pkg/component_map.go
@@ -46,11 +46,19 @@ type ModuleMapEntry struct {
 	Modules       map[string]*ModuleMapEntry   `json:"modules"`
 }
 
-// ResourceMapEntry describes a single resource within a module.
+// ResourceMapEntry describes a resource type within a module.
+// A single type.name in TF (e.g. aws_lb_listener.this) may have multiple
+// instances (via count or for_each), each with its own flat-state name.
 type ResourceMapEntry struct {
-	FlatName   string `json:"flatName"`
-	PulumiType string `json:"pulumiType"`
-	ShortName  string `json:"shortName"`
+	PulumiType string              `json:"pulumiType"`
+	Instances  []ResourceInstance  `json:"instances"`
+}
+
+// ResourceInstance describes a single instance of a resource within a module.
+type ResourceInstance struct {
+	FlatName  string `json:"flatName"`
+	ShortName string `json:"shortName"`
+	IndexKey  string `json:"indexKey,omitempty"`
 }
 
 // ModuleInterface describes the inputs and outputs of a component.
@@ -151,7 +159,7 @@ func buildModuleMapEntry(
 		}
 	}
 
-	// Match resources from state to this module
+	// Match resources from state to this module, accumulating instances per type.name
 	for _, res := range allResources {
 		segments := parseModuleSegments(res.Address)
 		resModulePath := buildModulePath(segments)
@@ -162,21 +170,31 @@ func buildModuleMapEntry(
 		// Build the resource map key: "resourceType.resourceName"
 		resMapKey := res.Type + "." + res.Name
 
-		// Determine PulumiType by looking up the provider
-		pulumiType := ""
-		prov, ok := pulumiProviders[providermap.TerraformProviderName(res.ProviderName)]
-		if ok {
-			tok, err := bridge.PulumiTypeToken(res.Type, prov.Provider)
-			if err == nil {
-				pulumiType = string(tok)
+		existing, ok := entry.Resources[resMapKey]
+		if !ok {
+			// Determine PulumiType by looking up the provider
+			pulumiType := ""
+			prov, provOk := pulumiProviders[providermap.TerraformProviderName(res.ProviderName)]
+			if provOk {
+				tok, err := bridge.PulumiTypeToken(res.Type, prov.Provider)
+				if err == nil {
+					pulumiType = string(tok)
+				}
 			}
+			existing = &ResourceMapEntry{
+				PulumiType: pulumiType,
+			}
+			entry.Resources[resMapKey] = existing
 		}
 
-		entry.Resources[resMapKey] = &ResourceMapEntry{
-			FlatName:   PulumiNameFromTerraformAddress(res.Address, res.Type),
-			PulumiType: pulumiType,
-			ShortName:  shortResourceName(res.Address, res.Type),
-		}
+		// Extract instance index key from the address
+		indexKey := extractResourceIndexKey(res.Address, res.Type, res.Name)
+
+		existing.Instances = append(existing.Instances, ResourceInstance{
+			FlatName:  PulumiNameFromTerraformAddress(res.Address, res.Type),
+			ShortName: shortResourceName(res.Address, res.Type),
+			IndexKey:  indexKey,
+		})
 	}
 
 	// Interface from metadata + component evaluated values
@@ -321,6 +339,29 @@ func shortResourceName(address, resourceType string) string {
 		}
 	}
 	return address
+}
+
+// extractResourceIndexKey extracts the instance index key from a fully qualified
+// resource address. For "module.vpc.aws_subnet.public[0]" it returns "0".
+// For "module.alb.aws_lb_listener.this[\"my-https-listener\"]" it returns "my-https-listener".
+// Returns "" if the resource has no index.
+func extractResourceIndexKey(address, resourceType, resourceName string) string {
+	// The resource portion is everything after the module path: "type.name" or "type.name[key]"
+	suffix := resourceType + "." + resourceName
+	idx := strings.LastIndex(address, suffix)
+	if idx == -1 {
+		return ""
+	}
+	after := address[idx+len(suffix):]
+	if !strings.HasPrefix(after, "[") || !strings.HasSuffix(after, "]") {
+		return ""
+	}
+	key := after[1 : len(after)-1]
+	// Strip surrounding quotes if present
+	if len(key) >= 2 && key[0] == '"' && key[len(key)-1] == '"' {
+		key = key[1 : len(key)-1]
+	}
+	return key
 }
 
 // stripModulePrefix removes the module path prefix from a resource address,

--- a/pkg/component_map.go
+++ b/pkg/component_map.go
@@ -55,6 +55,7 @@ type ResourceMapEntry struct {
 
 // ResourceInstance describes a single instance of a resource within a module.
 type ResourceInstance struct {
+	URN      string `json:"urn"`
 	FlatName string `json:"flatName"`
 	IndexKey string `json:"indexKey,omitempty"`
 }
@@ -100,6 +101,7 @@ func buildComponentMap(
 	metadata *ComponentSchemaMetadata,
 	components []PulumiResource,
 	pulumiProviders map[providermap.TerraformProviderName]*ProviderWithMetadata,
+	stackName, projectName string,
 ) *ComponentMap {
 	var allResources []stateResourceInfo
 	tofu.VisitResources(tfState, func(r *tfjson.StateResource) error {
@@ -118,7 +120,7 @@ func buildComponentMap(
 
 	for _, node := range tree {
 		key := moduleMapKey(node)
-		cm.Modules[key] = buildModuleMapEntry(node, allResources, metadata, components, pulumiProviders)
+		cm.Modules[key] = buildModuleMapEntry(node, allResources, metadata, components, pulumiProviders, stackName, projectName)
 	}
 
 	return cm
@@ -131,6 +133,7 @@ func buildModuleMapEntry(
 	metadata *ComponentSchemaMetadata,
 	components []PulumiResource,
 	pulumiProviders map[providermap.TerraformProviderName]*ProviderWithMetadata,
+	stackName, projectName string,
 ) *ModuleMapEntry {
 	entry := &ModuleMapEntry{
 		TerraformPath: node.modulePath,
@@ -187,8 +190,11 @@ func buildModuleMapEntry(
 		// Extract instance index key from the address
 		indexKey := extractResourceIndexKey(res.Address, res.Type, res.Name)
 
+		flatName := PulumiNameFromTerraformAddress(res.Address, res.Type)
+		urn := fmt.Sprintf("urn:pulumi:%s::%s::%s::%s", stackName, projectName, existing.PulumiType, flatName)
 		existing.Instances = append(existing.Instances, ResourceInstance{
-			FlatName: PulumiNameFromTerraformAddress(res.Address, res.Type),
+			URN:      urn,
+			FlatName: flatName,
 			IndexKey: indexKey,
 		})
 	}
@@ -249,7 +255,7 @@ func buildModuleMapEntry(
 	// Recurse into children
 	for _, child := range node.children {
 		key := moduleMapKey(child)
-		entry.Modules[key] = buildModuleMapEntry(child, allResources, metadata, components, pulumiProviders)
+		entry.Modules[key] = buildModuleMapEntry(child, allResources, metadata, components, pulumiProviders, stackName, projectName)
 	}
 
 	return entry

--- a/pkg/e2e_test.go
+++ b/pkg/e2e_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/pulumi/pulumi-tool-terraform-migrate/pkg/tofu"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/stretchr/testify/require"
 )
 
@@ -36,7 +37,7 @@ func loadDnsToDbState(t *testing.T) *TranslateStateResult {
 		StateFilePath: "testdata/tofu_state_dns_to_db.json",
 	})
 	require.NoError(t, err)
-	data, err := TranslateState(ctx, tfState, nil, "dev", "test-project", true, true, nil, nil, nil, "")
+	data, err := TranslateState(ctx, tfState, nil, "dev", "test-project", nil, nil, nil, "")
 	require.NoError(t, err)
 	return data
 }
@@ -74,27 +75,15 @@ func TestConvertDnsToDb_WithHCLAndModuleCache(t *testing.T) {
 	require.NoError(t, err)
 
 	// Pass tfSourceDir to enable HCL parsing + module cache resolution
-	data, err := TranslateState(ctx, tfState, nil, "dev", "test-project", true, true, nil, nil, nil, "testdata/tf_dns_to_db")
+	data, err := TranslateState(ctx, tfState, nil, "dev", "test-project", nil, nil, nil, "testdata/tf_dns_to_db")
 	require.NoError(t, err)
 
+	// No component resources in flat state
 	_, _, components, _ := classifyResources(t, data)
-	require.Equal(t, 18, len(components), "expected 18 component resources")
+	require.Len(t, components, 0, "state is always flat — no component resources")
 
-	// With module cache, most components should have populated inputs
-	withInputs := 0
-	withOutputs := 0
-	for _, c := range components {
-		if len(c.Inputs) > 0 {
-			withInputs++
-		}
-		if len(c.Outputs) > 0 {
-			withOutputs++
-		}
-	}
-	// Top-level modules should have inputs (from call-site eval with locals, data, tfvars, module cross-refs)
-	require.GreaterOrEqual(t, withInputs, 10, "at least 10 components should have populated inputs with module cache")
-
-	// Check component-schemas.json metadata is returned
+	// Component metadata should still be available via sidecar
+	require.NotNil(t, data.ComponentMapData, "should have component map data with HCL source")
 	require.NotNil(t, data.ComponentMetadata, "should return component schema metadata")
 	require.GreaterOrEqual(t, len(data.ComponentMetadata.Components), 10, "metadata should have entries for most modules")
 
@@ -128,7 +117,7 @@ func TestConvertDnsToDb_EvalWarningCount(t *testing.T) {
 	})
 	require.NoError(t, loadErr)
 
-	_, translateErr := TranslateState(ctx, tfState, nil, "dev", "test-project", true, true, nil, nil, nil, "testdata/tf_dns_to_db")
+	_, translateErr := TranslateState(ctx, tfState, nil, "dev", "test-project", nil, nil, nil, "testdata/tf_dns_to_db")
 	require.NoError(t, translateErr)
 
 	// Restore stderr and read captured output
@@ -159,58 +148,29 @@ func TestConvertDnsToDb(t *testing.T) {
 	t.Parallel()
 	data := loadDnsToDbState(t)
 
-	var components []apitype.ResourceV3
 	var customResources []apitype.ResourceV3
-	var rootResources []apitype.ResourceV3
-
 	stackURN := ""
 	for _, r := range data.Export.Deployment.Resources {
 		if string(r.Type) == "pulumi:pulumi:Stack" {
 			stackURN = string(r.URN)
 			continue
 		}
-		if !r.Custom {
-			components = append(components, r)
-			continue
-		}
-		// Check if this is a provider resource (type starts with "pulumi:providers:")
 		if isProvider(r) {
 			continue
 		}
-		customResources = append(customResources, r)
-		if string(r.Parent) == stackURN {
-			rootResources = append(rootResources, r)
+		if !r.Custom {
+			t.Fatalf("unexpected component resource in flat state: %s", r.Type)
 		}
+		customResources = append(customResources, r)
 	}
-
-	// 18 component instances (19 modules minus db_instance which has only data sources)
-	require.Len(t, components, 18, "expected 18 component resources")
 
 	// ~90 managed resources
 	require.GreaterOrEqual(t, len(customResources), 85, "expected ~90 managed resources")
 
-	// Root resources (not in any module) should be parented to Stack
-	require.GreaterOrEqual(t, len(rootResources), 5, "expected root resources parented to Stack")
-
-	// Verify for_each instances share the same type token
-	componentTypes := map[string][]string{} // type → names
-	for _, c := range components {
-		componentTypes[string(c.Type)] = append(componentTypes[string(c.Type)], string(c.URN))
+	// All resources should be parented to Stack (flat state)
+	for _, r := range customResources {
+		require.Equal(t, stackURN, string(r.Parent), "resource %s should be parented to Stack", r.URN)
 	}
-	// ec2_private_app1 has 2 instances → same type token
-	app1Type := "terraform:module/ec2PrivateApp1:Ec2PrivateApp1"
-	require.Len(t, componentTypes[app1Type], 2, "ec2_private_app1 should have 2 for_each instances")
-
-	// Verify nested module (rdsdb submodules) produce $-delimited URN type chain
-	var rdsdbChildren []apitype.ResourceV3
-	for _, c := range components {
-		urn := string(c.URN)
-		if contains(urn, "module/rdsdb:Rdsdb$") {
-			rdsdbChildren = append(rdsdbChildren, c)
-		}
-	}
-	// db_option_group, db_parameter_group, db_subnet_group (not db_instance — data sources only)
-	require.Len(t, rdsdbChildren, 3, "rdsdb should have 3 nested component children (db_instance skipped — data only)")
 }
 
 func TestConvertDnsToDb_TypeOverrides(t *testing.T) {
@@ -226,42 +186,15 @@ func TestConvertDnsToDb_TypeOverrides(t *testing.T) {
 		"module.ec2_private_app1": "myinfra:compute:AppServer",
 	}
 
-	data, err := TranslateState(ctx, tfState, nil, "dev", "test-project", true, true, typeOverrides, nil, nil, "")
+	data, err := TranslateState(ctx, tfState, nil, "dev", "test-project", typeOverrides, nil, nil, "")
 	require.NoError(t, err)
 
-	var components []apitype.ResourceV3
+	// No component resources in flat state
 	for _, r := range data.Export.Deployment.Resources {
 		if !r.Custom && string(r.Type) != "pulumi:pulumi:Stack" {
-			components = append(components, r)
+			t.Fatalf("unexpected component resource in flat state: %s", r.Type)
 		}
 	}
-
-	// vpc should have custom type
-	vpcFound := false
-	for _, c := range components {
-		if string(c.Type) == "myinfra:network:Vpc" {
-			vpcFound = true
-		}
-	}
-	require.True(t, vpcFound, "vpc should have overridden type myinfra:network:Vpc")
-
-	// Both ec2_private_app1 instances should have the custom type
-	app1Count := 0
-	for _, c := range components {
-		if string(c.Type) == "myinfra:compute:AppServer" {
-			app1Count++
-		}
-	}
-	require.Equal(t, 2, app1Count, "both ec2_private_app1 for_each instances should have custom type")
-
-	// Other modules should keep derived types
-	sgFound := false
-	for _, c := range components {
-		if string(c.Type) == "terraform:module/publicBastionSg:PublicBastionSg" {
-			sgFound = true
-		}
-	}
-	require.True(t, sgFound, "public_bastion_sg should keep auto-derived type")
 }
 
 func TestConvertDnsToDb_FlatMode(t *testing.T) {
@@ -272,8 +205,8 @@ func TestConvertDnsToDb_FlatMode(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// enableComponents=false → flat mode
-	data, err := TranslateState(ctx, tfState, nil, "dev", "test-project", false, true, nil, nil, nil, "")
+	// State is always flat
+	data, err := TranslateState(ctx, tfState, nil, "dev", "test-project", nil, nil, nil, "")
 	require.NoError(t, err)
 
 	// No component resources in flat mode
@@ -301,19 +234,6 @@ func TestConvertDnsToDb_FlatMode(t *testing.T) {
 
 // --- Helper functions ---
 
-func contains(s, substr string) bool {
-	return len(s) >= len(substr) && (s == substr || len(s) > 0 && findSubstring(s, substr))
-}
-
-func findSubstring(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
-	}
-	return false
-}
-
 func isProvider(r apitype.ResourceV3) bool {
 	const prefix = "pulumi:providers:"
 	return len(r.Type) >= len(prefix) && string(r.Type)[:len(prefix)] == prefix
@@ -329,25 +249,12 @@ func TestConvertMultiResourceModule(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	data, err := TranslateState(ctx, tfState, nil, "dev", "test-project", true, false, nil, nil, nil, "")
+	data, err := TranslateState(ctx, tfState, nil, "dev", "test-project", nil, nil, nil, "")
 	require.NoError(t, err)
 
 	_, _, components, custom := classifyResources(t, data)
-
-	// 1 component: zoo
-	require.Len(t, components, 1, "expected 1 component (zoo)")
-	zoo := components[0]
-	require.Equal(t, "terraform:module/zoo:Zoo", string(zoo.Type))
-
-	// 3 child resources parented to zoo
-	zooURN := string(zoo.URN)
-	var children []apitype.ResourceV3
-	for _, r := range custom {
-		if string(r.Parent) == zooURN {
-			children = append(children, r)
-		}
-	}
-	require.Len(t, children, 3, "expected 3 child resources (random_pet, random_string, random_integer)")
+	require.Len(t, components, 0, "no components in flat state")
+	require.Len(t, custom, 3, "expected 3 resources in zoo module")
 }
 
 func TestConvertMultiResourceModule_WithHCL(t *testing.T) {
@@ -358,23 +265,22 @@ func TestConvertMultiResourceModule_WithHCL(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	data, err := TranslateState(ctx, tfState, nil, "dev", "test-project", true, true, nil, nil, nil, "testdata/tf_multi_resource_module")
+	data, err := TranslateState(ctx, tfState, nil, "dev", "test-project", nil, nil, nil, "testdata/tf_multi_resource_module")
 	require.NoError(t, err)
 
 	_, _, components, _ := classifyResources(t, data)
-	require.Len(t, components, 1)
+	require.Len(t, components, 0, "no components in flat state")
 
-	zoo := components[0]
-
-	// Component inputs should contain prefix
-	require.NotNil(t, zoo.Inputs, "component inputs should not be nil")
-	require.Equal(t, "myprefix", zoo.Inputs["prefix"], "prefix input should be 'myprefix'")
-
-	// Component outputs should have animal_name and tag keys
-	require.NotNil(t, zoo.Outputs, "component outputs should not be nil")
-	_, hasAnimalName := zoo.Outputs["animal_name"]
+	// ComponentMapData should have zoo module with inputs/outputs
+	require.NotNil(t, data.ComponentMapData)
+	require.Len(t, data.ComponentMapData.Components, 1)
+	zoo := data.ComponentMapData.Components[0]
+	require.NotNil(t, zoo.Inputs, "zoo component should have inputs")
+	require.Equal(t, resource.NewStringProperty("myprefix"), zoo.Inputs[resource.PropertyKey("prefix")])
+	require.NotNil(t, zoo.Outputs, "zoo component should have outputs")
+	_, hasAnimalName := zoo.Outputs[resource.PropertyKey("animal_name")]
 	require.True(t, hasAnimalName, "outputs should have animal_name key")
-	_, hasTag := zoo.Outputs["tag"]
+	_, hasTag := zoo.Outputs[resource.PropertyKey("tag")]
 	require.True(t, hasTag, "outputs should have tag key")
 }
 
@@ -388,40 +294,11 @@ func TestConvertDeepNestedMixed(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	data, err := TranslateState(ctx, tfState, nil, "dev", "test-project", true, true, nil, nil, nil, "")
+	data, err := TranslateState(ctx, tfState, nil, "dev", "test-project", nil, nil, nil, "")
 	require.NoError(t, err)
 
 	_, _, components, _ := classifyResources(t, data)
-
-	// 10 total components: 2 env + 4 svc + 4 instance
-	require.Len(t, components, 10, "expected 10 components (2 env + 4 svc + 4 instance)")
-
-	// URN type chain should use $ for nesting (full form: ...Env$terraform:module/svc:Svc$terraform:module/instance:Instance)
-	foundNestedType := false
-	for _, c := range components {
-		urn := string(c.URN)
-		if contains(urn, "Svc$terraform:module/instance:Instance") {
-			foundNestedType = true
-			break
-		}
-	}
-	require.True(t, foundNestedType, "should have $-delimited nested URN type chain")
-
-	// env-dev should sort before env-prod (alphabetical ordering)
-	devIdx := -1
-	prodIdx := -1
-	for i, r := range data.Export.Deployment.Resources {
-		urn := string(r.URN)
-		if contains(urn, "env-dev") && devIdx == -1 {
-			devIdx = i
-		}
-		if contains(urn, "env-prod") && prodIdx == -1 {
-			prodIdx = i
-		}
-	}
-	require.Greater(t, devIdx, -1, "env-dev should be present")
-	require.Greater(t, prodIdx, -1, "env-prod should be present")
-	require.Less(t, devIdx, prodIdx, "env-dev should sort before env-prod")
+	require.Len(t, components, 0, "no components in flat state")
 }
 
 func TestConvertDeepNestedMixed_FlatMode(t *testing.T) {
@@ -432,11 +309,11 @@ func TestConvertDeepNestedMixed_FlatMode(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	data, err := TranslateState(ctx, tfState, nil, "dev", "test-project", false, false, nil, nil, nil, "")
+	data, err := TranslateState(ctx, tfState, nil, "dev", "test-project", nil, nil, nil, "")
 	require.NoError(t, err)
 
 	_, _, components, _ := classifyResources(t, data)
-	require.Len(t, components, 0, "flat mode should produce 0 components")
+	require.Len(t, components, 0, "state should produce 0 components")
 
 	// All managed resources should be parented to Stack
 	stackURN := ""
@@ -450,7 +327,7 @@ func TestConvertDeepNestedMixed_FlatMode(t *testing.T) {
 		if !r.Custom || isProvider(r) || string(r.Type) == "pulumi:pulumi:Stack" {
 			continue
 		}
-		require.Equal(t, stackURN, string(r.Parent), "resource %s should be parented to Stack in flat mode", r.URN)
+		require.Equal(t, stackURN, string(r.Parent), "resource %s should be parented to Stack", r.URN)
 	}
 }
 
@@ -464,36 +341,35 @@ func TestConvertComplexExpressions(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	data, err := TranslateState(ctx, tfState, nil, "dev", "test-project", true, true, nil, nil, nil, "testdata/tf_complex_expressions")
+	data, err := TranslateState(ctx, tfState, nil, "dev", "test-project", nil, nil, nil, "testdata/tf_complex_expressions")
 	require.NoError(t, err)
 
 	_, _, components, _ := classifyResources(t, data)
+	require.Len(t, components, 0, "no components in flat state")
 
-	// Find svc-0 and svc-1 components by URN
-	var svc0, svc1 *apitype.ResourceV3
-	for i, c := range components {
-		urn := string(c.URN)
-		if contains(urn, "svc-0") && !contains(urn, "svc-01") {
-			svc0 = &components[i]
+	require.NotNil(t, data.ComponentMapData)
+	// Find svc-0 and svc-1 in ComponentMapData.Components by name
+	var svc0, svc1 *PulumiResource
+	for i, c := range data.ComponentMapData.Components {
+		if c.Name == "svc-0" {
+			svc0 = &data.ComponentMapData.Components[i]
 		}
-		if contains(urn, "svc-1") {
-			svc1 = &components[i]
+		if c.Name == "svc-1" {
+			svc1 = &data.ComponentMapData.Components[i]
 		}
 	}
-	require.NotNil(t, svc0, "svc-0 component should exist")
-	require.NotNil(t, svc1, "svc-1 component should exist")
+	require.NotNil(t, svc0, "svc-0 should exist in component map data")
+	require.NotNil(t, svc1, "svc-1 should exist in component map data")
 
-	// svc-0: prefix="svc-00", is_primary=true, label="SERVICE-0"
 	require.NotNil(t, svc0.Inputs)
-	require.Equal(t, "svc-00", svc0.Inputs["prefix"], "svc-0 prefix should be 'svc-00'")
-	require.Equal(t, true, svc0.Inputs["is_primary"], "svc-0 is_primary should be true")
-	require.Equal(t, "SERVICE-0", svc0.Inputs["label"], "svc-0 label should be 'SERVICE-0'")
+	require.Equal(t, resource.NewStringProperty("svc-00"), svc0.Inputs[resource.PropertyKey("prefix")])
+	require.Equal(t, resource.NewBoolProperty(true), svc0.Inputs[resource.PropertyKey("is_primary")])
+	require.Equal(t, resource.NewStringProperty("SERVICE-0"), svc0.Inputs[resource.PropertyKey("label")])
 
-	// svc-1: prefix="svc-01", is_primary=false, label="SERVICE-1"
 	require.NotNil(t, svc1.Inputs)
-	require.Equal(t, "svc-01", svc1.Inputs["prefix"], "svc-1 prefix should be 'svc-01'")
-	require.Equal(t, false, svc1.Inputs["is_primary"], "svc-1 is_primary should be false")
-	require.Equal(t, "SERVICE-1", svc1.Inputs["label"], "svc-1 label should be 'SERVICE-1'")
+	require.Equal(t, resource.NewStringProperty("svc-01"), svc1.Inputs[resource.PropertyKey("prefix")])
+	require.Equal(t, resource.NewBoolProperty(false), svc1.Inputs[resource.PropertyKey("is_primary")])
+	require.Equal(t, resource.NewStringProperty("SERVICE-1"), svc1.Inputs[resource.PropertyKey("label")])
 }
 
 // --- Tfvars resolution (Fixture 5) ---
@@ -506,19 +382,19 @@ func TestConvertTfvarsResolution(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	data, err := TranslateState(ctx, tfState, nil, "dev", "test-project", true, true, nil, nil, nil, "testdata/tf_tfvars_resolution")
+	data, err := TranslateState(ctx, tfState, nil, "dev", "test-project", nil, nil, nil, "testdata/tf_tfvars_resolution")
 	require.NoError(t, err)
 
 	_, _, components, _ := classifyResources(t, data)
-	require.GreaterOrEqual(t, len(components), 1, "should have at least 1 component")
+	require.Len(t, components, 0, "no components in flat state")
 
-	// Component inputs should have prefix="staging" (from tfvars env="staging")
-	// suffix="prod" is a variable default — should NOT be in state (belongs in component-schemas.json)
-	comp := components[0]
-	require.NotNil(t, comp.Inputs, "component inputs should not be nil")
-	require.Equal(t, "staging", comp.Inputs["prefix"], "prefix should be 'staging' from tfvars")
-	_, hasSuffix := comp.Inputs["suffix"]
-	require.False(t, hasSuffix, "variable defaults should not be in state")
+	require.NotNil(t, data.ComponentMapData)
+	require.GreaterOrEqual(t, len(data.ComponentMapData.Components), 1)
+	comp := data.ComponentMapData.Components[0]
+	require.NotNil(t, comp.Inputs)
+	require.Equal(t, resource.NewStringProperty("staging"), comp.Inputs[resource.PropertyKey("prefix")])
+	_, hasSuffix := comp.Inputs[resource.PropertyKey("suffix")]
+	require.False(t, hasSuffix, "variable defaults should not be in inputs")
 }
 
 // --- Special key sanitization (Fixture 6) ---
@@ -531,29 +407,11 @@ func TestConvertSpecialKeyModules(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	data, err := TranslateState(ctx, tfState, nil, "dev", "test-project", true, false, nil, nil, nil, "")
+	data, err := TranslateState(ctx, tfState, nil, "dev", "test-project", nil, nil, nil, "")
 	require.NoError(t, err)
 
 	_, _, components, _ := classifyResources(t, data)
-	require.Len(t, components, 3, "expected 3 components")
-
-	// Names should be sanitized
-	expectedNames := map[string]bool{
-		"region-us-east-1":         false,
-		"region-eu-west-1-zone-a":  false,
-		"region-ap-southeast-2":    false,
-	}
-	for _, c := range components {
-		urn := string(c.URN)
-		for name := range expectedNames {
-			if contains(urn, name) {
-				expectedNames[name] = true
-			}
-		}
-	}
-	for name, found := range expectedNames {
-		require.True(t, found, "should find sanitized component name: %s", name)
-	}
+	require.Len(t, components, 0, "no components in flat state")
 }
 
 // --- Flat mode sweep (all fixtures) ---
@@ -584,7 +442,7 @@ func TestConvertFlatMode_AllFixtures(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			data, err := TranslateState(ctx, tfState, nil, "dev", "test-project", false, false, nil, nil, nil, "")
+			data, err := TranslateState(ctx, tfState, nil, "dev", "test-project", nil, nil, nil, "")
 			require.NoError(t, err)
 
 			_, _, components, _ := classifyResources(t, data)

--- a/pkg/module_tree.go
+++ b/pkg/module_tree.go
@@ -316,34 +316,3 @@ func toComponents(nodes []*componentNode, parentTypeChain string) []PulumiResour
 	return result
 }
 
-// componentParentForResource returns the parent type chain for a resource at the given module path.
-func componentParentForResource(nodes []*componentNode, segments []moduleSegment) string {
-	if len(segments) == 0 {
-		return ""
-	}
-
-	current := nodes
-	var typeChain string
-	for _, seg := range segments {
-		targetName := seg.name
-		if seg.key != "" {
-			targetName = sanitizeModuleInstanceName(seg.name, seg.key)
-		}
-		found := false
-		for _, node := range current {
-			if node.resourceName == targetName {
-				if typeChain != "" {
-					typeChain += "$"
-				}
-				typeChain += node.typeToken
-				current = node.children
-				found = true
-				break
-			}
-		}
-		if !found {
-			return ""
-		}
-	}
-	return typeChain
-}

--- a/pkg/module_tree_test.go
+++ b/pkg/module_tree_test.go
@@ -170,32 +170,6 @@ func TestToComponents_DepthFirst(t *testing.T) {
 	require.Equal(t, "terraform:module/vpc:Vpc", components[1].Parent) // child of vpc
 }
 
-func TestComponentParentForResource(t *testing.T) {
-	tree, err := buildComponentTree(
-		[]string{
-			"module.vpc.module.subnets.aws_subnet.this",
-			"module.vpc.aws_vpc.main",
-		},
-		nil,
-	)
-	require.NoError(t, err)
-
-	// Resource in nested module
-	segments := parseModuleSegments("module.vpc.module.subnets.aws_subnet.this")
-	parent := componentParentForResource(tree, segments)
-	require.Equal(t, "terraform:module/vpc:Vpc$terraform:module/subnets:Subnets", parent)
-
-	// Resource in top-level module
-	segments = parseModuleSegments("module.vpc.aws_vpc.main")
-	parent = componentParentForResource(tree, segments)
-	require.Equal(t, "terraform:module/vpc:Vpc", parent)
-
-	// Root resource (no module)
-	segments = parseModuleSegments("aws_s3_bucket.this")
-	parent = componentParentForResource(tree, segments)
-	require.Equal(t, "", parent)
-}
-
 func TestParseModuleSegments(t *testing.T) {
 	tests := []struct {
 		address  string

--- a/pkg/pulumi_state.go
+++ b/pkg/pulumi_state.go
@@ -34,15 +34,6 @@ func makeUrn(stackName, projectName, typeName, resourceName string) resource.URN
 	return resource.URN(fmt.Sprintf("urn:pulumi:%s::%s::%s::%s", stackName, projectName, typeName, resourceName))
 }
 
-// makeUrnWithParent creates a Pulumi URN with a parent type chain encoded via $ delimiters.
-func makeUrnWithParent(stackName, projectName, parentTypeChain, typeName, resourceName string) resource.URN {
-	fullType := typeName
-	if parentTypeChain != "" {
-		fullType = parentTypeChain + "$" + typeName
-	}
-	return resource.URN(fmt.Sprintf("urn:pulumi:%s::%s::%s::%s", stackName, projectName, fullType, resourceName))
-}
-
 // Identifier within a stack.
 type PulumiResourceID struct {
 	ID   string
@@ -73,7 +64,6 @@ type PulumiResource struct {
 
 type PulumiState struct {
 	Providers         []PulumiResource
-	Components        []PulumiResource
 	Resources         []PulumiResource
 	ComponentMetadata *ComponentSchemaMetadata
 }
@@ -167,48 +157,6 @@ func InsertResourcesIntoDeployment(state *PulumiState, stackName, projectName st
 		deployment.Resources = append(deployment.Resources, provider)
 	}
 
-	// Insert component resources (after providers, before custom resources).
-	// Components are in depth-first order, so parents are always inserted before children.
-	componentURNs := map[string]resource.URN{} // type chain -> URN
-
-	for _, comp := range state.Components {
-		urn := makeUrnWithParent(stackName, projectName, comp.Parent, comp.Type, comp.Name)
-
-		parentURN := stackURN
-		if comp.Parent != "" {
-			if parentComponentURN, ok := componentURNs[comp.Parent]; ok {
-				parentURN = parentComponentURN
-			}
-		}
-
-		// Register this component's full type chain for child lookups
-		fullTypeChain := comp.Type
-		if comp.Parent != "" {
-			fullTypeChain = comp.Parent + "$" + comp.Type
-		}
-		componentURNs[fullTypeChain] = urn
-
-		inputs := comp.Inputs
-		if inputs == nil {
-			inputs = resource.PropertyMap{}
-		}
-		outputs := comp.Outputs
-		if outputs == nil {
-			outputs = resource.PropertyMap{}
-		}
-
-		deployment.Resources = append(deployment.Resources, apitype.ResourceV3{
-			URN:      urn,
-			Custom:   false,
-			Type:     tokens.Type(comp.Type),
-			Inputs:   inputs.Mappable(),
-			Outputs:  outputs.Mappable(),
-			Parent:   parentURN,
-			Created:  &now,
-			Modified: &now,
-		})
-	}
-
 	for _, res := range state.Resources {
 		contract.Assertf(res.Provider != nil, "Expected a provider association for a custom resource")
 
@@ -220,14 +168,7 @@ func InsertResourcesIntoDeployment(state *PulumiState, stackName, projectName st
 		providerURN := makeUrn(stackName, projectName, providerRecord.Type, providerRecord.Name)
 		providerLink := fmt.Sprintf("%s::%s", providerURN, providerRecord.ID)
 
-		urn := makeUrnWithParent(stackName, projectName, res.Parent, res.Type, res.Name)
-
-		parentURN := stackURN
-		if res.Parent != "" {
-			if parentComponentURN, ok := componentURNs[res.Parent]; ok {
-				parentURN = parentComponentURN
-			}
-		}
+		urn := makeUrn(stackName, projectName, res.Type, res.Name)
 
 		deployment.Resources = append(deployment.Resources, apitype.ResourceV3{
 			URN:      urn,
@@ -236,7 +177,7 @@ func InsertResourcesIntoDeployment(state *PulumiState, stackName, projectName st
 			Type:     tokens.Type(res.Type),
 			Inputs:   res.Inputs.Mappable(),
 			Outputs:  res.Outputs.Mappable(),
-			Parent:   parentURN,
+			Parent:   stackURN,
 			Provider: providerLink,
 			Created:  &now,
 			Modified: &now,

--- a/pkg/pulumi_state_test.go
+++ b/pkg/pulumi_state_test.go
@@ -17,7 +17,6 @@ package pkg
 import (
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/hexops/autogold/v2"
@@ -225,7 +224,7 @@ func TestInsertResourcesIntoDeployment_EmptyProjectName(t *testing.T) {
 	require.Contains(t, err.Error(), "projectName")
 }
 
-func TestInsertResourcesIntoDeployment_WithComponents(t *testing.T) {
+func TestInsertResourcesIntoDeployment_FlatState(t *testing.T) {
 	stackName := "dev"
 	projectName := "testproject"
 
@@ -234,17 +233,10 @@ func TestInsertResourcesIntoDeployment_WithComponents(t *testing.T) {
 		Providers: []PulumiResource{
 			{PulumiResourceID: providerID, Inputs: resource.PropertyMap{}, Outputs: resource.PropertyMap{}},
 		},
-		Components: []PulumiResource{
-			{
-				PulumiResourceID: PulumiResourceID{Name: "vpc", Type: "terraform:module/vpc:Vpc"},
-				Parent:           "",
-			},
-		},
 		Resources: []PulumiResource{
 			{
 				PulumiResourceID: PulumiResourceID{ID: "subnet-123", Name: "this", Type: "aws:ec2/subnet:Subnet"},
 				Provider:         &providerID,
-				Parent:           "terraform:module/vpc:Vpc",
 				Inputs:           resource.PropertyMap{},
 				Outputs:          resource.PropertyMap{},
 			},
@@ -254,28 +246,20 @@ func TestInsertResourcesIntoDeployment_WithComponents(t *testing.T) {
 	result, err := InsertResourcesIntoDeployment(state, stackName, projectName)
 	require.NoError(t, err)
 
-	// Stack + provider + component + resource = 4
-	require.Len(t, result.Resources, 4)
+	// Stack + provider + resource = 3
+	require.Len(t, result.Resources, 3)
 
-	// Verify ordering: Stack, provider, component, resource
+	// Verify ordering: Stack, provider, resource
 	require.Equal(t, tokens.Type("pulumi:pulumi:Stack"), result.Resources[0].Type)
-	require.True(t, result.Resources[1].Custom)  // provider
-	require.False(t, result.Resources[2].Custom) // component
-	require.True(t, result.Resources[3].Custom)  // resource
+	require.True(t, result.Resources[1].Custom) // provider
+	require.True(t, result.Resources[2].Custom) // resource
 
-	// Verify component resource
-	component := result.Resources[2]
-	require.False(t, component.Custom)
-	require.Equal(t, tokens.Type("terraform:module/vpc:Vpc"), component.Type)
-	require.Empty(t, component.ID)
-	require.Empty(t, component.Provider)
-
-	// Verify resource is parented to component
-	res := result.Resources[3]
-	require.Contains(t, string(res.Parent), "terraform:module/vpc:Vpc")
+	// Verify resource is parented to Stack (flat state)
+	res := result.Resources[2]
+	require.Contains(t, string(res.Parent), "pulumi:pulumi:Stack")
 }
 
-func TestInsertResourcesIntoDeployment_NestedComponents(t *testing.T) {
+func TestInsertResourcesIntoDeployment_FlatState_MultipleResources(t *testing.T) {
 	stackName := "dev"
 	projectName := "testproject"
 
@@ -284,21 +268,10 @@ func TestInsertResourcesIntoDeployment_NestedComponents(t *testing.T) {
 		Providers: []PulumiResource{
 			{PulumiResourceID: providerID, Inputs: resource.PropertyMap{}, Outputs: resource.PropertyMap{}},
 		},
-		Components: []PulumiResource{
-			{
-				PulumiResourceID: PulumiResourceID{Name: "vpc", Type: "terraform:module/vpc:Vpc"},
-				Parent:           "",
-			},
-			{
-				PulumiResourceID: PulumiResourceID{Name: "subnets", Type: "terraform:module/subnets:Subnets"},
-				Parent:           "terraform:module/vpc:Vpc",
-			},
-		},
 		Resources: []PulumiResource{
 			{
 				PulumiResourceID: PulumiResourceID{ID: "subnet-1", Name: "this", Type: "aws:ec2/subnet:Subnet"},
 				Provider:         &providerID,
-				Parent:           "terraform:module/vpc:Vpc$terraform:module/subnets:Subnets",
 				Inputs:           resource.PropertyMap{},
 				Outputs:          resource.PropertyMap{},
 			},
@@ -307,19 +280,11 @@ func TestInsertResourcesIntoDeployment_NestedComponents(t *testing.T) {
 
 	result, err := InsertResourcesIntoDeployment(state, stackName, projectName)
 	require.NoError(t, err)
-	require.Len(t, result.Resources, 5) // Stack + provider + 2 components + resource
+	require.Len(t, result.Resources, 3) // Stack + provider + resource
 
-	// subnets component should be parented to vpc component
-	subnets := result.Resources[3]
-	require.False(t, subnets.Custom)
-	require.Contains(t, string(subnets.Parent), "terraform:module/vpc:Vpc")
-
-	// resource should be parented to subnets component
-	res := result.Resources[4]
-	require.Contains(t, string(res.Parent), "terraform:module/subnets:Subnets")
-
-	// URN should encode parent type chain with $ delimiter
-	require.True(t, strings.Contains(string(res.URN), "terraform:module/vpc:Vpc$terraform:module/subnets:Subnets$aws:ec2/subnet:Subnet"))
+	// resource should be parented to Stack (flat state)
+	res := result.Resources[2]
+	require.Contains(t, string(res.Parent), "pulumi:pulumi:Stack")
 }
 
 func TestInsertResourcesIntoDeployment_NoComponents_BackwardCompat(t *testing.T) {
@@ -331,7 +296,6 @@ func TestInsertResourcesIntoDeployment_NoComponents_BackwardCompat(t *testing.T)
 		Providers: []PulumiResource{
 			{PulumiResourceID: providerID, Inputs: resource.PropertyMap{}, Outputs: resource.PropertyMap{}},
 		},
-		Components: nil,
 		Resources: []PulumiResource{
 			{
 				PulumiResourceID: PulumiResourceID{ID: "abc", Name: "test", Type: "random:index/randomPet:RandomPet"},

--- a/pkg/state_adapter.go
+++ b/pkg/state_adapter.go
@@ -142,6 +142,7 @@ func TranslateAndWriteState(
 			res.ComponentMapData.Metadata,
 			res.ComponentMapData.Components,
 			res.PulumiProviders,
+			stackName, projectName,
 		)
 		mapPath := filepath.Join(filepath.Dir(outputFilePath), "component-map.json")
 		if err := WriteComponentMap(cm, mapPath); err != nil {

--- a/pkg/state_adapter.go
+++ b/pkg/state_adapter.go
@@ -56,8 +56,6 @@ func TranslateAndWriteState(
 	outputFilePath string,
 	requiredProvidersOutputFilePath string,
 	strict bool,
-	enableComponents bool,
-	populateComponentInputs bool,
 	typeOverrides map[string]string,
 	sourceOverrides map[string]string,
 	schemaOverrides map[string]string,
@@ -107,7 +105,7 @@ func TranslateAndWriteState(
 		}
 	}
 
-	res, err := TranslateState(ctx, tfState, providerVersions.ProviderSelections, stackName, projectName, enableComponents, populateComponentInputs, typeOverrides, sourceOverrides, schemaOverrides, tfDir)
+	res, err := TranslateState(ctx, tfState, providerVersions.ProviderSelections, stackName, projectName, typeOverrides, sourceOverrides, schemaOverrides, tfDir)
 	if err != nil {
 		return err
 	}
@@ -133,6 +131,21 @@ func TranslateAndWriteState(
 		metadataPath := filepath.Join(filepath.Dir(outputFilePath), "component-schemas.json")
 		if err := WriteComponentSchemaMetadata(res.ComponentMetadata, metadataPath); err != nil {
 			return fmt.Errorf("failed to write component schema metadata: %w", err)
+		}
+	}
+
+	// Write component-map.json sidecar file
+	if res.ComponentMapData != nil {
+		cm := buildComponentMap(
+			res.ComponentMapData.Tree,
+			tfState,
+			res.ComponentMapData.Metadata,
+			res.ComponentMapData.Components,
+			res.PulumiProviders,
+		)
+		mapPath := filepath.Join(filepath.Dir(outputFilePath), "component-map.json")
+		if err := WriteComponentMap(cm, mapPath); err != nil {
+			return fmt.Errorf("failed to write component map: %w", err)
 		}
 	}
 
@@ -163,15 +176,19 @@ type TranslateStateResult struct {
 	ErrorMessages     []ErroredResource
 	// ComponentMetadata is non-nil when HCL sources were available and parsed.
 	ComponentMetadata *ComponentSchemaMetadata
+	// ComponentMapData holds the intermediate data needed to build the component-map.json sidecar.
+	ComponentMapData *ComponentMapData
+	// PulumiProviders is the resolved provider map, exposed so callers can build the component map.
+	PulumiProviders map[providermap.TerraformProviderName]*ProviderWithMetadata
 }
 
-func TranslateState(ctx context.Context, tfState *tfjson.State, providerVersions map[string]string, stackName, projectName string, enableComponents bool, populateComponentInputs bool, typeOverrides map[string]string, sourceOverrides map[string]string, schemaOverrides map[string]string, tfSourceDir string) (*TranslateStateResult, error) {
+func TranslateState(ctx context.Context, tfState *tfjson.State, providerVersions map[string]string, stackName, projectName string, typeOverrides map[string]string, sourceOverrides map[string]string, schemaOverrides map[string]string, tfSourceDir string) (*TranslateStateResult, error) {
 	pulumiProviders, err := GetPulumiProvidersForTerraformState(tfState, providerVersions)
 	if err != nil {
 		return nil, err
 	}
 
-	pulumiState, errorMessages, err := convertState(tfState, pulumiProviders, enableComponents, populateComponentInputs, typeOverrides, sourceOverrides, schemaOverrides, tfSourceDir)
+	pulumiState, errorMessages, componentMapData, err := convertState(tfState, pulumiProviders, typeOverrides, sourceOverrides, schemaOverrides, tfSourceDir)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert state: %w", err)
 	}
@@ -191,6 +208,8 @@ func TranslateState(ctx context.Context, tfState *tfjson.State, providerVersions
 		RequiredProviders: requiredProviders,
 		ErrorMessages:     errorMessages,
 		ComponentMetadata: pulumiState.ComponentMetadata,
+		ComponentMapData:  componentMapData,
+		PulumiProviders:   pulumiProviders,
 	}, nil
 }
 
@@ -201,7 +220,7 @@ type ErroredResource struct {
 	ErrorMessage     string `json:"error_message"`
 }
 
-func convertState(tfState *tfjson.State, pulumiProviders map[providermap.TerraformProviderName]*ProviderWithMetadata, enableComponents bool, populateComponentInputs bool, typeOverrides map[string]string, sourceOverrides map[string]string, schemaOverrides map[string]string, tfSourceDir string) (*PulumiState, []ErroredResource, error) {
+func convertState(tfState *tfjson.State, pulumiProviders map[providermap.TerraformProviderName]*ProviderWithMetadata, typeOverrides map[string]string, sourceOverrides map[string]string, schemaOverrides map[string]string, tfSourceDir string) (*PulumiState, []ErroredResource, *ComponentMapData, error) {
 	pulumiState := &PulumiState{}
 
 	// TODO[pulumi/pulumi-service#35512]: This assumes one Pulumi provider per Terraform provider.
@@ -211,7 +230,7 @@ func convertState(tfState *tfjson.State, pulumiProviders map[providermap.Terrafo
 	for tfProviderName, provider := range pulumiProviders {
 		inputs, err := GetProviderInputs(provider.Name)
 		if err != nil {
-			return nil, nil, fmt.Errorf("failed to get provider inputs: %w", err)
+			return nil, nil, nil, fmt.Errorf("failed to get provider inputs: %w", err)
 		}
 		uuid := uuid.NewString()
 		providerResource := PulumiResource{
@@ -228,30 +247,31 @@ func convertState(tfState *tfjson.State, pulumiProviders map[providermap.Terrafo
 		providerTable[tfProviderName] = providerResource.PulumiResourceID
 	}
 
-	// Build component tree from module hierarchy if enabled
-	var componentTree []*componentNode
-	if enableComponents {
-		var resourceAddresses []string
-		tofu.VisitResources(tfState, func(r *tfjson.StateResource) error {
-			resourceAddresses = append(resourceAddresses, r.Address)
-			return nil
-		}, &tofu.VisitOptions{})
+	// Build component tree from module hierarchy when source dir is available
+	var componentMapData *ComponentMapData
+	var resourceAddresses []string
+	tofu.VisitResources(tfState, func(r *tfjson.StateResource) error {
+		resourceAddresses = append(resourceAddresses, r.Address)
+		return nil
+	}, &tofu.VisitOptions{})
 
-		if len(resourceAddresses) > 0 {
-			var err error
-			componentTree, err = buildComponentTree(resourceAddresses, typeOverrides)
-			if err != nil {
-				return nil, nil, fmt.Errorf("failed to build component tree: %w", err)
-			}
-			pulumiState.Components = toComponents(componentTree, "")
-
-			// Populate component inputs/outputs from HCL when source is available
-			scopedAttrs := buildScopedResourceAttrMap(tfState)
-			metadata, err := populateComponentsFromHCL(pulumiState.Components, componentTree, sourceOverrides, schemaOverrides, tfSourceDir, populateComponentInputs, scopedAttrs, tfState)
-			if err != nil {
-				return nil, nil, fmt.Errorf("failed to populate component state from HCL: %w", err)
-			}
-			pulumiState.ComponentMetadata = metadata
+	if len(resourceAddresses) > 0 && tfSourceDir != "" {
+		componentTree, err := buildComponentTree(resourceAddresses, typeOverrides)
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("failed to build component tree: %w", err)
+		}
+		tempComponents := toComponents(componentTree, "")
+		scopedAttrs := buildScopedResourceAttrMap(tfState)
+		metadata, err := populateComponentsFromHCL(tempComponents, componentTree,
+			sourceOverrides, schemaOverrides, tfSourceDir, true, scopedAttrs, tfState)
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("failed to populate component metadata from HCL: %w", err)
+		}
+		pulumiState.ComponentMetadata = metadata
+		componentMapData = &ComponentMapData{
+			Tree:       componentTree,
+			Components: tempComponents,
+			Metadata:   metadata,
 		}
 	}
 
@@ -282,21 +302,14 @@ func convertState(tfState *tfjson.State, pulumiProviders map[providermap.Terrafo
 		}
 		pulumiResource.Provider = &providerLink
 
-		// When components are enabled, use short name and set parent
-		if enableComponents {
-			pulumiResource.Name = PulumiNameFromTerraformAddress(resource.Address, resource.Type, true)
-			segments := parseModuleSegments(resource.Address)
-			pulumiResource.Parent = componentParentForResource(componentTree, segments)
-		}
-
 		pulumiState.Resources = append(pulumiState.Resources, pulumiResource)
 		return nil
 	}, &tofu.VisitOptions{})
 	if err != nil {
-		return nil, errorMessages, fmt.Errorf("failed to visit resources: %w", err)
+		return nil, errorMessages, nil, fmt.Errorf("failed to visit resources: %w", err)
 	}
 
-	return pulumiState, errorMessages, nil
+	return pulumiState, errorMessages, componentMapData, nil
 }
 
 func convertResourceStateExceptProviderLink(
@@ -346,7 +359,7 @@ func convertResourceStateExceptProviderLink(
 	return PulumiResource{
 		PulumiResourceID: PulumiResourceID{
 			ID:   props["id"].StringValue(),
-			Name: PulumiNameFromTerraformAddress(res.Address, res.Type, false),
+			Name: PulumiNameFromTerraformAddress(res.Address, res.Type),
 			Type: string(pulumiTypeToken),
 		},
 		Inputs:  inputs,
@@ -375,21 +388,11 @@ func formatDynamicProviderName(tfAddr string) string {
 //   - Submodule: module.<module_name>.<resource_type>.<name> e.g., "module.s3_bucket.aws_s3_bucket.this"
 //   - Nested: module.<mod1>.module.<mod2>.<resource_type>.<name>
 //
-// When useShortName is true, only the resource name after the type is returned (module path is
-// expressed via the parent component chain instead). When false, module path is baked into the name.
-func PulumiNameFromTerraformAddress(address, resourceType string, useShortName bool) string {
+// The module path is baked into the returned name to produce a globally unique flat name.
+func PulumiNameFromTerraformAddress(address, resourceType string) string {
 	parts := strings.Split(address, ".")
 
-	if useShortName {
-		// Return only the resource name part (after the type)
-		for i := 0; i < len(parts); i++ {
-			if parts[i] == resourceType {
-				return strings.Join(parts[i+1:], "_")
-			}
-		}
-	}
-
-	// Original behavior: include module path in name
+	// Include module path in name
 	var nameParts []string
 	for i := 0; i < len(parts); i++ {
 		if parts[i] == resourceType {

--- a/pkg/state_adapter_test.go
+++ b/pkg/state_adapter_test.go
@@ -16,11 +16,9 @@ package pkg
 
 import (
 	"context"
-	"strings"
 	"testing"
 
 	"github.com/pulumi/pulumi-tool-terraform-migrate/pkg/tofu"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/stretchr/testify/require"
@@ -57,8 +55,8 @@ func TestConvertInvolved(t *testing.T) {
 		t.Fatalf("failed to convert Terraform state: %v", err)
 	}
 
-	// 24 original resources + 1 component for module.data_lake_bucket
-	require.Len(t, data.Export.Deployment.Resources, 25)
+	// 24 original resources (flat state — no component resources)
+	require.Len(t, data.Export.Deployment.Resources, 24)
 }
 
 func TestConvertTwoModules(t *testing.T) {
@@ -87,8 +85,8 @@ func TestConvertTwoModules_FlatMode(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// enableComponents=false: flat mode, no component resources
-	data, err := TranslateState(ctx, tfState, nil, "dev", "test-project", false, true, nil, nil, nil, "")
+	// State is always flat — no component resources
+	data, err := TranslateState(ctx, tfState, nil, "dev", "test-project", nil, nil, nil, "")
 	require.NoError(t, err)
 
 	// No component resources in flat mode
@@ -125,19 +123,12 @@ func TestConvertIndexedModules(t *testing.T) {
 	data, err := translateStateFromJson(ctx, "testdata/tofu_state_indexed_modules.json")
 	require.NoError(t, err)
 
-	var components []apitype.ResourceV3
+	// No component resources in flat state
 	for _, r := range data.Export.Deployment.Resources {
 		if !r.Custom && string(r.Type) != "pulumi:pulumi:Stack" {
-			components = append(components, r)
+			t.Fatalf("unexpected component resource in flat state: %s", r.Type)
 		}
 	}
-	require.Len(t, components, 2, "expected 2 component resources (pet-0, pet-1)")
-	// Same type token for both instances
-	require.Equal(t, components[0].Type, components[1].Type)
-	// Different URNs
-	require.NotEqual(t, string(components[0].URN), string(components[1].URN))
-	// Type token is derived from module name
-	require.Equal(t, tokens.Type("terraform:module/pet:Pet"), components[0].Type)
 }
 
 func TestConvertKeyedModules(t *testing.T) {
@@ -146,31 +137,12 @@ func TestConvertKeyedModules(t *testing.T) {
 	data, err := translateStateFromJson(ctx, "testdata/tofu_state_keyed_modules.json")
 	require.NoError(t, err)
 
-	var components []apitype.ResourceV3
+	// No component resources in flat state
 	for _, r := range data.Export.Deployment.Resources {
 		if !r.Custom && string(r.Type) != "pulumi:pulumi:Stack" {
-			components = append(components, r)
+			t.Fatalf("unexpected component resource in flat state: %s", r.Type)
 		}
 	}
-	require.Len(t, components, 2, "expected 2 component resources (pet-alpha, pet-beta)")
-	// Same type token
-	require.Equal(t, components[0].Type, components[1].Type)
-	// Different URNs
-	require.NotEqual(t, string(components[0].URN), string(components[1].URN))
-
-	// Check both keys are represented in URNs
-	alphaFound, betaFound := false, false
-	for _, c := range components {
-		urn := string(c.URN)
-		if strings.Contains(urn, "alpha") {
-			alphaFound = true
-		}
-		if strings.Contains(urn, "beta") {
-			betaFound = true
-		}
-	}
-	require.True(t, alphaFound, "expected component with 'alpha' key")
-	require.True(t, betaFound, "expected component with 'beta' key")
 }
 
 func TestConvertNestedModules(t *testing.T) {
@@ -213,30 +185,32 @@ func TestConvertWithHCLPopulation(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// Pass tfSourceDir so HCL parsing populates component inputs
-	data, err := TranslateState(ctx, tfState, nil, "dev", "test-project", true, true, nil, nil, nil, "testdata/tf_indexed_modules")
+	// Pass tfSourceDir so HCL parsing populates component map data
+	data, err := TranslateState(ctx, tfState, nil, "dev", "test-project", nil, nil, nil, "testdata/tf_indexed_modules")
 	require.NoError(t, err)
 
-	// Find component resources
-	var components []apitype.ResourceV3
+	// No component resources in flat state
 	for _, r := range data.Export.Deployment.Resources {
 		if !r.Custom && string(r.Type) != "pulumi:pulumi:Stack" {
-			components = append(components, r)
+			t.Fatalf("unexpected component resource in flat state: %s", r.Type)
 		}
 	}
-	require.Len(t, components, 2)
 
-	// Components should have inputs populated — prefix uses count.index
-	// which is now resolved from the component's key (0, 1)
-	for _, comp := range components {
-		require.NotNil(t, comp.Inputs, "component %s should have inputs", comp.URN)
-		require.Contains(t, comp.Inputs, "prefix", "component %s should have prefix input", comp.URN)
+	// ComponentMapData should have the component information
+	require.NotNil(t, data.ComponentMapData)
+	require.NotNil(t, data.ComponentMapData.Tree)
+	require.Len(t, data.ComponentMapData.Tree, 2) // pet[0] and pet[1]
+
+	// Components should have inputs populated
+	for _, comp := range data.ComponentMapData.Components {
+		require.NotNil(t, comp.Inputs, "component %s should have inputs", comp.Name)
+		require.Contains(t, comp.Inputs, resource.PropertyKey("prefix"), "component %s should have prefix input", comp.Name)
 	}
 
 	// Components should also have outputs populated from module output declarations
-	for _, comp := range components {
-		require.NotNil(t, comp.Outputs, "component %s should have outputs", comp.URN)
-		require.Contains(t, comp.Outputs, "name", "component %s should have name output", comp.URN)
+	for _, comp := range data.ComponentMapData.Components {
+		require.NotNil(t, comp.Outputs, "component %s should have outputs", comp.Name)
+		require.Contains(t, comp.Outputs, resource.PropertyKey("name"), "component %s should have name output", comp.Name)
 	}
 }
 
@@ -244,22 +218,18 @@ func TestConvertWithHCLPopulation_NoSource(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 
-	// Without tfSourceDir, components should have empty inputs/outputs (no error)
+	// Without tfSourceDir, ComponentMapData should be nil
 	data, err := translateStateFromJson(ctx, "testdata/tofu_state_indexed_modules.json")
 	require.NoError(t, err)
 
-	var components []apitype.ResourceV3
+	// No component resources in flat state
 	for _, r := range data.Export.Deployment.Resources {
 		if !r.Custom && string(r.Type) != "pulumi:pulumi:Stack" {
-			components = append(components, r)
+			t.Fatalf("unexpected component resource in flat state: %s", r.Type)
 		}
 	}
-	require.Len(t, components, 2)
 
-	// Without HCL source, inputs should be empty
-	for _, comp := range components {
-		require.Empty(t, comp.Inputs, "component %s should have empty inputs without HCL source", comp.URN)
-	}
+	require.Nil(t, data.ComponentMapData, "should not have component map data without HCL source")
 }
 
 func TestConvertWithSchemaValidation(t *testing.T) {
@@ -275,21 +245,14 @@ func TestConvertWithSchemaValidation(t *testing.T) {
 		"module.pet": "testdata/schemas/pet_component_schema.json",
 	}
 
-	data, err := TranslateState(ctx, tfState, nil, "dev", "test-project", true, true, nil, nil, schemaOverrides, "testdata/tf_indexed_modules")
+	data, err := TranslateState(ctx, tfState, nil, "dev", "test-project", nil, nil, schemaOverrides, "testdata/tf_indexed_modules")
 	require.NoError(t, err)
 
-	// Find component resources and verify they have populated inputs/outputs
-	var components []apitype.ResourceV3
-	for _, r := range data.Export.Deployment.Resources {
-		if !r.Custom && string(r.Type) != "pulumi:pulumi:Stack" {
-			components = append(components, r)
-		}
-	}
-	require.Len(t, components, 2)
-
-	for _, comp := range components {
-		require.Contains(t, comp.Inputs, "prefix", "component %s should have prefix input", comp.URN)
-		require.Contains(t, comp.Outputs, "name", "component %s should have name output", comp.URN)
+	// ComponentMapData should have the component information
+	require.NotNil(t, data.ComponentMapData)
+	for _, comp := range data.ComponentMapData.Components {
+		require.Contains(t, comp.Inputs, resource.PropertyKey("prefix"))
+		require.Contains(t, comp.Outputs, resource.PropertyKey("name"))
 	}
 }
 
@@ -309,22 +272,15 @@ func TestConvertWithSchemaValidation_CustomTypeToken(t *testing.T) {
 		"module.pet": "testdata/schemas/pet_custom_component_schema.json",
 	}
 
-	data, err := TranslateState(ctx, tfState, nil, "dev", "test-project", true, true, typeOverrides, nil, schemaOverrides, "testdata/tf_indexed_modules")
+	data, err := TranslateState(ctx, tfState, nil, "dev", "test-project", typeOverrides, nil, schemaOverrides, "testdata/tf_indexed_modules")
 	require.NoError(t, err)
 
-	var components []apitype.ResourceV3
-	for _, r := range data.Export.Deployment.Resources {
-		if !r.Custom && string(r.Type) != "pulumi:pulumi:Stack" {
-			components = append(components, r)
-		}
-	}
-	require.Len(t, components, 2)
-
-	// Components should use the custom type token
-	for _, comp := range components {
+	// ComponentMapData should have the component information with custom type
+	require.NotNil(t, data.ComponentMapData)
+	for _, comp := range data.ComponentMapData.Components {
 		require.Contains(t, string(comp.Type), "myproject:index:PetComponent")
-		require.Contains(t, comp.Inputs, "prefix")
-		require.Contains(t, comp.Outputs, "name")
+		require.Contains(t, comp.Inputs, resource.PropertyKey("prefix"))
+		require.Contains(t, comp.Outputs, resource.PropertyKey("name"))
 	}
 }
 
@@ -341,7 +297,7 @@ func TestConvertWithSchemaValidation_Mismatch(t *testing.T) {
 		"module.pet": "testdata/schemas/pet_component_schema_mismatch.json",
 	}
 
-	_, err = TranslateState(ctx, tfState, nil, "dev", "test-project", true, true, nil, nil, schemaOverrides, "testdata/tf_indexed_modules")
+	_, err = TranslateState(ctx, tfState, nil, "dev", "test-project", nil, nil, schemaOverrides, "testdata/tf_indexed_modules")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "region")
 	require.Contains(t, err.Error(), "required by schema")
@@ -354,7 +310,7 @@ func translateStateFromJson(ctx context.Context, tfStateJson string) (*Translate
 	if err != nil {
 		return nil, err
 	}
-	return TranslateState(ctx, tfState, nil, "dev", "test-project", true, true, nil, nil, nil, "")
+	return TranslateState(ctx, tfState, nil, "dev", "test-project", nil, nil, nil, "")
 }
 
 func Test_convertState_simple(t *testing.T) {
@@ -369,7 +325,7 @@ func Test_convertState_simple(t *testing.T) {
 	pulumiProviders, err := GetPulumiProvidersForTerraformState(tfState, nil)
 	require.NoError(t, err, "failed to get Pulumi providers")
 
-	pulumiState, errorMessages, err := convertState(tfState, pulumiProviders, false, true, nil, nil, nil, "")
+	pulumiState, errorMessages, _, err := convertState(tfState, pulumiProviders, nil, nil, nil, "")
 	require.NoError(t, err, "failed to convert state")
 	require.Equal(t, 0, len(errorMessages), "expected no error messages")
 
@@ -396,7 +352,7 @@ func Test_convertState_multi_provider(t *testing.T) {
 	pulumiProviders, err := GetPulumiProvidersForTerraformState(tfState, nil)
 	require.NoError(t, err, "failed to get Pulumi providers")
 
-	pulumiState, errorMessages, err := convertState(tfState, pulumiProviders, false, true, nil, nil, nil, "")
+	pulumiState, errorMessages, _, err := convertState(tfState, pulumiProviders, nil, nil, nil, "")
 	require.NoError(t, err, "failed to convert state")
 	require.Equal(t, 0, len(errorMessages), "expected no error messages")
 
@@ -451,7 +407,7 @@ func Test_convertState_corrupted_state(t *testing.T) {
 	pulumiProviders, err := GetPulumiProvidersForTerraformState(tfState, nil)
 	require.NoError(t, err, "failed to get Pulumi providers")
 
-	_, errorMessages, err := convertState(tfState, pulumiProviders, false, true, nil, nil, nil, "")
+	_, errorMessages, _, err := convertState(tfState, pulumiProviders, nil, nil, nil, "")
 	require.NoError(t, err, "failed to convert state")
 	require.Equal(t, 1, len(errorMessages), "expected 1 error message")
 	require.Equal(t, "password", errorMessages[0].ResourceName)
@@ -474,7 +430,7 @@ func Test_convertState_unknown_provider(t *testing.T) {
 
 	require.Len(t, pulumiProviders, 1, "should only have 1 provider (random)")
 
-	pulumiState, errorMessages, err := convertState(tfState, pulumiProviders, false, true, nil, nil, nil, "")
+	pulumiState, errorMessages, _, err := convertState(tfState, pulumiProviders, nil, nil, nil, "")
 	require.NoError(t, err, "failed to convert state")
 
 	require.Len(t, errorMessages, 1, "expected 1 error message for unknown_resource")
@@ -526,48 +482,6 @@ func TestFormatDynamicProviderName(t *testing.T) {
 	}
 }
 
-func TestPulumiNameFromTerraformAddress_ShortName(t *testing.T) {
-	t.Parallel()
-	tests := []struct {
-		name         string
-		address      string
-		resourceType string
-		expected     string
-	}{
-		{
-			name:         "root module resource",
-			address:      "aws_s3_bucket.mybucket",
-			resourceType: "aws_s3_bucket",
-			expected:     "mybucket",
-		},
-		{
-			name:         "single module resource",
-			address:      "module.vpc.aws_subnet.this",
-			resourceType: "aws_subnet",
-			expected:     "this",
-		},
-		{
-			name:         "indexed module resource",
-			address:      "module.vpc[0].aws_subnet.this",
-			resourceType: "aws_subnet",
-			expected:     "this",
-		},
-		{
-			name:         "nested module resource",
-			address:      "module.vpc.module.subnets.aws_subnet.this",
-			resourceType: "aws_subnet",
-			expected:     "this",
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			result := PulumiNameFromTerraformAddress(tc.address, tc.resourceType, true)
-			require.Equal(t, tc.expected, result)
-		})
-	}
-}
-
 func TestPulumiNameFromTerraformAddress(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
@@ -610,7 +524,7 @@ func TestPulumiNameFromTerraformAddress(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			result := PulumiNameFromTerraformAddress(tc.address, tc.resourceType, false)
+			result := PulumiNameFromTerraformAddress(tc.address, tc.resourceType)
 			require.Equal(t, tc.expected, result)
 		})
 	}

--- a/pkg/statefile/translate.go
+++ b/pkg/statefile/translate.go
@@ -84,7 +84,7 @@ func TranslateResourceInstance(
 	return pkg.PulumiResource{
 		PulumiResourceID: pkg.PulumiResourceID{
 			ID:   props["id"].StringValue(),
-			Name: pkg.PulumiNameFromTerraformAddress(res.Addr.Instance(key).String(), resourceType, false),
+			Name: pkg.PulumiNameFromTerraformAddress(res.Addr.Instance(key).String(), resourceType),
 			Type: string(pulumiTypeToken),
 		},
 		Inputs:  inputs,

--- a/test/translate_test.go
+++ b/test/translate_test.go
@@ -101,7 +101,7 @@ func TestTranslateBasic(t *testing.T) {
 
 	ctx := context.Background()
 
-	err := pkg.TranslateAndWriteState(ctx, statePath, "", stackFolder, filepath.Join(stackFolder, "state.json"), "", false, true, true, nil, nil, nil, "", "")
+	err := pkg.TranslateAndWriteState(ctx, statePath, "", stackFolder, filepath.Join(stackFolder, "state.json"), "", false, nil, nil, nil, "", "")
 	require.NoError(t, err)
 
 	_ = runCommand(t, stackFolder, "pulumi", "stack", "import", "--file", filepath.Join(stackFolder, "state.json"))
@@ -135,7 +135,7 @@ func TestTranslateBasicWithDependencies(t *testing.T) {
 	statePath := setupTFStack(t, "testdata/tf_random_stack")
 	stackFolder, _ := createPulumiStack(t)
 
-	err := pkg.TranslateAndWriteState(ctx, statePath, "", stackFolder, filepath.Join(stackFolder, "state.json"), filepath.Join(stackFolder, "dependencies.json"), false, true, true, nil, nil, nil, "", "")
+	err := pkg.TranslateAndWriteState(ctx, statePath, "", stackFolder, filepath.Join(stackFolder, "state.json"), filepath.Join(stackFolder, "dependencies.json"), false, nil, nil, nil, "", "")
 	require.NoError(t, err)
 
 	dependencies, err := os.ReadFile(filepath.Join(stackFolder, "dependencies.json"))
@@ -151,7 +151,7 @@ func TestTranslateBasicWithEdit(t *testing.T) {
 	statePath := setupTFStack(t, "testdata/tf_random_stack")
 	stackFolder, stackName := createPulumiStack(t)
 
-	err := pkg.TranslateAndWriteState(ctx, statePath, "", stackFolder, filepath.Join(stackFolder, "state.json"), "", false, true, true, nil, nil, nil, "", "")
+	err := pkg.TranslateAndWriteState(ctx, statePath, "", stackFolder, filepath.Join(stackFolder, "state.json"), "", false, nil, nil, nil, "", "")
 	require.NoError(t, err)
 
 	_ = runCommand(t, stackFolder, "pulumi", "stack", "import", "--file", filepath.Join(stackFolder, "state.json"))
@@ -209,7 +209,7 @@ func TestTranslateWithDependency(t *testing.T) {
 	statePath := setupTFStack(t, "testdata/tf_dependency_stack")
 	stackFolder, stackName := createPulumiStack(t)
 
-	err := pkg.TranslateAndWriteState(ctx, statePath, "", stackFolder, filepath.Join(stackFolder, "state.json"), "", false, true, true, nil, nil, nil, "", "")
+	err := pkg.TranslateAndWriteState(ctx, statePath, "", stackFolder, filepath.Join(stackFolder, "state.json"), "", false, nil, nil, nil, "", "")
 	require.NoError(t, err)
 
 	_ = runCommand(t, stackFolder, "pulumi", "stack", "import", "--file", filepath.Join(stackFolder, "state.json"))


### PR DESCRIPTION
Remove ComponentResource entries from Pulumi state entirely. The tool now
always produces flat state (resources parented to Stack) and writes module
metadata to a component-map.json sidecar file for downstream code generation.

- Add ComponentMap structs, buildComponentMap(), WriteComponentMap()
- Remove PulumiState.Components, component insertion in deployment, and
  componentParentForResource()
- Remove enableComponents/populateComponentInputs from convertState() and
  TranslateState() signatures
- Remove --no-module-components and --component-inputs CLI flags
- Wire component-map.json writing into TranslateAndWriteState()
- Update all tests to verify flat state and ComponentMapData

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>