### PR TITLE
Fix provider map poisoning by pulumi-terraform-bridge version bumps

### DIFF
--- a/cmd/update_providermap.go
+++ b/cmd/update_providermap.go
@@ -17,6 +17,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strings"
 	"sync"
 
 	"github.com/pulumi/pulumi-tool-terraform-migrate/pkg/providermap"
@@ -85,6 +86,15 @@ func updateProviderMap(versionMapPath string, provider string, recompute bool, p
 			return
 		}
 
+		// Versions the Terraform registry actually serves for this provider, used to
+		// reject inferred upstream versions that cannot be downloaded (yanked releases,
+		// or misparsed versions of tools like pulumi-terraform-bridge). If the registry
+		// cannot be queried, validation is skipped rather than failing every version.
+		registryVersions, validateRegistry := providermap.FetchRegistryVersions(bp)
+		if !validateRegistry {
+			fmt.Fprintf(os.Stderr, "  Warning: cannot validate upstream versions for %s against the Terraform registry\n", bp)
+		}
+
 		// For every tag not yet in the VersionMap, try to infer upstream version
 		for _, tag := range tags {
 			var hasVersion bool
@@ -101,6 +111,10 @@ func updateProviderMap(versionMapPath string, provider string, recompute bool, p
 			}
 
 			upstreamVersion, err := providermap.InferUpstreamVersion(bp, tag)
+			if err == nil && validateRegistry &&
+				!registryVersions[strings.TrimPrefix(string(upstreamVersion), "v")] {
+				err = fmt.Errorf("inferred upstream version %s is not available from the Terraform registry", upstreamVersion)
+			}
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "  %s: %v\n", tag, err)
 				if mu != nil {

--- a/cmd/update_providermap.go
+++ b/cmd/update_providermap.go
@@ -17,7 +17,6 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"strings"
 	"sync"
 
 	"github.com/pulumi/pulumi-tool-terraform-migrate/pkg/providermap"
@@ -86,14 +85,8 @@ func updateProviderMap(versionMapPath string, provider string, recompute bool, p
 			return
 		}
 
-		// Versions the Terraform registry actually serves for this provider, used to
-		// reject inferred upstream versions that cannot be downloaded (yanked releases,
-		// or misparsed versions of tools like pulumi-terraform-bridge). If the registry
-		// cannot be queried, validation is skipped rather than failing every version.
-		registryVersions, validateRegistry := providermap.FetchRegistryVersions(bp)
-		if !validateRegistry {
-			fmt.Fprintf(os.Stderr, "  Warning: cannot validate upstream versions for %s against the Terraform registry\n", bp)
-		}
+		// Rejects inferred upstream versions the Terraform registry does not serve.
+		validateUpstream := providermap.NewUpstreamVersionValidator(bp)
 
 		// For every tag not yet in the VersionMap, try to infer upstream version
 		for _, tag := range tags {
@@ -111,9 +104,8 @@ func updateProviderMap(versionMapPath string, provider string, recompute bool, p
 			}
 
 			upstreamVersion, err := providermap.InferUpstreamVersion(bp, tag)
-			if err == nil && validateRegistry &&
-				!registryVersions[strings.TrimPrefix(string(upstreamVersion), "v")] {
-				err = fmt.Errorf("inferred upstream version %s is not available from the Terraform registry", upstreamVersion)
+			if err == nil {
+				err = validateUpstream(upstreamVersion)
 			}
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "  %s: %v\n", tag, err)

--- a/pkg/providermap/commits.go
+++ b/pkg/providermap/commits.go
@@ -33,18 +33,22 @@ var versionPattern = regexp.MustCompile(`(?i)(?:terraform|upstream).*to\s+(v?\d+
 // "pulumi-terraform-bridge" or "terraform-plugin-sdk". Version bumps of these must not
 // be mistaken for upstream provider upgrades (e.g. "Upgrade pulumi-terraform-bridge to
 // v3.130.0" previously recorded v3.130.0 as the provider's upstream version). Separators
-// vary in the wild ("Upgrade pulumi terraform bridge to v3.59.0"), hence [-/ ].
+// vary in the wild ("Upgrade pulumi terraform bridge to v3.59.0"), hence [-/ ]. The
+// trailing "to <version>" is consumed along with the name so that another
+// "terraform"/"upstream" token on the same line (e.g. "terraform: upgrade
+// pulumi-terraform-bridge to v3.130.0") cannot bind versionPattern to the tool's version.
 var nonUpstreamTerraformPattern = regexp.MustCompile(
-	`(?i)(?:pulumi[-/ ])?terraform[- ]bridge|terraform[- ]plugin[- ][a-z0-9-]+`)
+	`(?i)(?:(?:pulumi[-/ ])?terraform[- ]bridge|terraform[- ]plugin[- ][a-z0-9-]+)` +
+		`(?:\s+to\s+v?\d+\.\d+\.\d+(?:[-+][a-zA-Z0-9.-]+)?)?`)
 
 // parseVersionFromCommitMsg extracts a version string from a commit message.
 // It looks for patterns like "Upgrade terraform-provider-random to v3.8.0" and returns
 // the version string (e.g., "v3.8.0"). If multiple versions are found, it returns the
 // largest version by semantic versioning rules. Returns an error if no version is found.
 func parseVersionFromCommitMsg(message string) (ReleaseTag, error) {
-	// Mask bridge/plugin-library names so their embedded "terraform" cannot
-	// trigger versionPattern; "bridge" alone is already excluded by the pattern.
-	message = nonUpstreamTerraformPattern.ReplaceAllString(message, "bridge")
+	// Strip bridge/plugin-library bumps so their embedded "terraform" and their
+	// version cannot trigger versionPattern.
+	message = nonUpstreamTerraformPattern.ReplaceAllString(message, "")
 	allMatches := versionPattern.FindAllStringSubmatch(message, -1)
 	if len(allMatches) == 0 {
 		return "", fmt.Errorf("no upstream version found in commit message")

--- a/pkg/providermap/commits.go
+++ b/pkg/providermap/commits.go
@@ -28,11 +28,23 @@ import (
 // The version is captured in group 1
 var versionPattern = regexp.MustCompile(`(?i)(?:terraform|upstream).*to\s+(v?\d+\.\d+\.\d+(?:[-+][a-zA-Z0-9.-]+)?)`)
 
+// nonUpstreamTerraformPattern matches tool and library names that contain the word
+// "terraform" but never refer to the upstream Terraform provider, such as
+// "pulumi-terraform-bridge" or "terraform-plugin-sdk". Version bumps of these must not
+// be mistaken for upstream provider upgrades (e.g. "Upgrade pulumi-terraform-bridge to
+// v3.130.0" previously recorded v3.130.0 as the provider's upstream version). Separators
+// vary in the wild ("Upgrade pulumi terraform bridge to v3.59.0"), hence [-/ ].
+var nonUpstreamTerraformPattern = regexp.MustCompile(
+	`(?i)(?:pulumi[-/ ])?terraform[- ]bridge|terraform[- ]plugin[- ][a-z0-9-]+`)
+
 // parseVersionFromCommitMsg extracts a version string from a commit message.
 // It looks for patterns like "Upgrade terraform-provider-random to v3.8.0" and returns
 // the version string (e.g., "v3.8.0"). If multiple versions are found, it returns the
 // largest version by semantic versioning rules. Returns an error if no version is found.
 func parseVersionFromCommitMsg(message string) (ReleaseTag, error) {
+	// Mask bridge/plugin-library names so their embedded "terraform" cannot
+	// trigger versionPattern; "bridge" alone is already excluded by the pattern.
+	message = nonUpstreamTerraformPattern.ReplaceAllString(message, "bridge")
 	allMatches := versionPattern.FindAllStringSubmatch(message, -1)
 	if len(allMatches) == 0 {
 		return "", fmt.Errorf("no upstream version found in commit message")

--- a/pkg/providermap/commits_test.go
+++ b/pkg/providermap/commits_test.go
@@ -174,6 +174,31 @@ Update upstream to 2.0.0-alpha.5`,
 			expected:    "v2.5.0",
 			expectError: false,
 		},
+		{
+			name:        "pulumi-terraform-bridge bump should not match",
+			message:     "Upgrade pulumi-terraform-bridge to v3.130.0",
+			expected:    "",
+			expectError: true,
+		},
+		{
+			name:        "terraform-plugin-sdk bump should not match",
+			message:     "Upgrade terraform-plugin-sdk to v2.34.0",
+			expected:    "",
+			expectError: true,
+		},
+		{
+			name:        "Space-separated bridge bump should not match",
+			message:     "Upgrade pulumi terraform bridge to v3.59.0 (#405)",
+			expected:    "",
+			expectError: true,
+		},
+		{
+			name: "Bridge bump must not win over provider upgrade",
+			message: `Upgrade pulumi-terraform-bridge to v3.130.0
+Upgrade terraform-provider-random to v3.9.0`,
+			expected:    "v3.9.0",
+			expectError: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/providermap/commits_test.go
+++ b/pkg/providermap/commits_test.go
@@ -193,6 +193,18 @@ Update upstream to 2.0.0-alpha.5`,
 			expectError: true,
 		},
 		{
+			name:        "Bridge bump on a line with another terraform token should not match",
+			message:     "terraform: upgrade pulumi-terraform-bridge to v3.130.0",
+			expected:    "",
+			expectError: true,
+		},
+		{
+			name:        "Bridge bump on a line mentioning upstream should not match",
+			message:     "Update upstream deps: bump pulumi-terraform-bridge to v3.130.0",
+			expected:    "",
+			expectError: true,
+		},
+		{
 			name: "Bridge bump must not win over provider upgrade",
 			message: `Upgrade pulumi-terraform-bridge to v3.130.0
 Upgrade terraform-provider-random to v3.9.0`,

--- a/pkg/providermap/infer.go
+++ b/pkg/providermap/infer.go
@@ -124,9 +124,12 @@ func InferUpstreamVersion(bp BridgedProvider, tag ReleaseTag) (ReleaseTag, error
 	return inferUpstreamVersionFromReleaseNotes(bp, tag, repoDir)
 }
 
-// isValidGitRepo reports whether dir exists and git recognizes it as a repository.
+// isValidGitRepo reports whether dir is itself a git repository. Statting dir/.git
+// rather than dir alone matters because rev-parse searches upward: a reaped cache
+// whose enclosing directory happens to be inside some repository must not pass, or
+// later git commands would silently read that repository instead.
 func isValidGitRepo(dir string) bool {
-	if _, err := os.Stat(dir); err != nil {
+	if _, err := os.Stat(filepath.Join(dir, ".git")); err != nil {
 		return false
 	}
 	cmd := exec.Command("git", "rev-parse", "--git-dir")

--- a/pkg/providermap/infer.go
+++ b/pkg/providermap/infer.go
@@ -67,8 +67,13 @@ func InferUpstreamVersion(bp BridgedProvider, tag ReleaseTag) (ReleaseTag, error
 	cacheDir := filepath.Join(cacheBase, fmt.Sprintf("pulumi-%s", bp))
 	repoDir := filepath.Join(cacheDir, "repo")
 
-	// Check if repo already exists
-	if _, err := os.Stat(repoDir); os.IsNotExist(err) {
+	// Check if repo already exists and is a usable git repository. The cache lives under
+	// os.TempDir(), where cleaners may reap files while leaving the directory tree behind,
+	// so mere existence of repoDir is not enough.
+	if !isValidGitRepo(repoDir) {
+		if err := os.RemoveAll(repoDir); err != nil {
+			return "", fmt.Errorf("failed to remove stale cache repo: %w", err)
+		}
 		// Create cache directory if it doesn't exist
 		if err := os.MkdirAll(cacheDir, 0755); err != nil {
 			return "", fmt.Errorf("failed to create cache dir: %w", err)
@@ -117,6 +122,16 @@ func InferUpstreamVersion(bp BridgedProvider, tag ReleaseTag) (ReleaseTag, error
 
 	// Fall back to fetching release notes and parsing those.
 	return inferUpstreamVersionFromReleaseNotes(bp, tag, repoDir)
+}
+
+// isValidGitRepo reports whether dir exists and git recognizes it as a repository.
+func isValidGitRepo(dir string) bool {
+	if _, err := os.Stat(dir); err != nil {
+		return false
+	}
+	cmd := exec.Command("git", "rev-parse", "--git-dir")
+	cmd.Dir = dir
+	return cmd.Run() == nil
 }
 
 func inferUpstreamVersionFromCommitMsg(repoDir string) (ReleaseTag, error) {

--- a/pkg/providermap/providermap.go
+++ b/pkg/providermap/providermap.go
@@ -650,8 +650,9 @@ func RecommendPulumiProvider(tf TerraformProvider) RecommendedPulumiProvider {
 	var recommendedVersion ReleaseTag
 
 	if tfVersion == "" {
-		// If no desired TF version, use latest.
-		recommendedVersion = latestVersion(versionPairs)
+		// If no desired TF version, use latest. Pass the unfiltered pairs so providers
+		// whose entries are all errors still resolve to their newest Pulumi release.
+		recommendedVersion = latestVersion(originalVersionPairs)
 	} else {
 		tfSemver, err := semver.Parse(tfVersion)
 		contract.AssertNoErrorf(err, "A non-empty tfVersion should be a valid semver: %v", err)
@@ -707,6 +708,12 @@ func latestVersion(versionPairs []VersionPair) ReleaseTag {
 			continue
 		}
 		return vp.Pulumi
+	}
+	// No entry has a known upstream version (e.g. upstream inference failed for every
+	// release of this provider). The newest Pulumi release is still the best available
+	// recommendation.
+	if len(versionPairs) > 0 {
+		return versionPairs[0].Pulumi
 	}
 	contract.Failf("Expected to always find the latest version in data")
 	return ""

--- a/pkg/providermap/providermap_test.go
+++ b/pkg/providermap/providermap_test.go
@@ -116,6 +116,19 @@ func TestRecommendPulumiProvider(t *testing.T) {
 			expectedVersion:              "",
 			expectedUseTerraformProvider: true,
 		},
+		{
+			// Every slack entry in versions.yaml is an error entry (upstream version
+			// inference failed for all of its releases), so this exercises the fallback
+			// to the newest Pulumi release when no upstream mapping is known.
+			name: "Slack - provider with only error entries recommends newest release",
+			input: TerraformProvider{
+				Identifier: "registry.terraform.io/jmatsu/slack",
+				Version:    "",
+			},
+			expectedBridgedProvider:      "slack",
+			expectedMinVersion:           "v0.5.0",
+			expectedUseTerraformProvider: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/providermap/registry.go
+++ b/pkg/providermap/registry.go
@@ -1,0 +1,82 @@
+// Copyright 2016-2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package providermap
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// FetchRegistryVersions returns the set of upstream provider versions (without the "v"
+// prefix) that the Terraform registry actually serves for the given bridged provider.
+// It returns ok=false when the provider has no registry.terraform.io mapping or the
+// registry could not be queried; callers should skip validation in that case rather
+// than treat it as "no versions available".
+//
+// Used in internal offline tooling only.
+func FetchRegistryVersions(bp BridgedProvider) (map[string]bool, bool) {
+	var addrs []string
+	for addr, detail := range providerMapping {
+		s := string(addr)
+		if detail.pulumiProviderName == string(bp) && strings.HasPrefix(s, "registry.terraform.io/") {
+			addrs = append(addrs, strings.TrimPrefix(s, "registry.terraform.io/"))
+		}
+	}
+	if len(addrs) == 0 {
+		return nil, false
+	}
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	available := map[string]bool{}
+	ok := false
+	for _, a := range addrs {
+		versions, err := fetchRegistryVersionList(client, a)
+		if err != nil {
+			continue
+		}
+		ok = true
+		for _, v := range versions {
+			available[v] = true
+		}
+	}
+	return available, ok
+}
+
+func fetchRegistryVersionList(client *http.Client, nsName string) ([]string, error) {
+	resp, err := client.Get("https://registry.terraform.io/v1/providers/" + nsName + "/versions")
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("registry returned status %d for %s", resp.StatusCode, nsName)
+	}
+	var payload struct {
+		Versions []struct {
+			Version string `json:"version"`
+		} `json:"versions"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return nil, err
+	}
+	versions := make([]string, 0, len(payload.Versions))
+	for _, v := range payload.Versions {
+		versions = append(versions, v.Version)
+	}
+	return versions, nil
+}

--- a/pkg/providermap/registry.go
+++ b/pkg/providermap/registry.go
@@ -18,18 +18,46 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
 	"strings"
+	"sync"
 	"time"
 )
 
-// FetchRegistryVersions returns the set of upstream provider versions (without the "v"
-// prefix) that the Terraform registry actually serves for the given bridged provider.
-// It returns ok=false when the provider has no registry.terraform.io mapping or the
-// registry could not be queried; callers should skip validation in that case rather
-// than treat it as "no versions available".
+// NewUpstreamVersionValidator returns a function that rejects inferred upstream versions
+// the Terraform registry does not actually serve for the given bridged provider (yanked
+// releases, or misparsed versions of tools like pulumi-terraform-bridge). The registry
+// is queried lazily on first use, so providers with nothing to infer never hit the
+// network. If it cannot be queried (or the provider has no registry.terraform.io
+// mapping), a warning is printed once and every version is accepted rather than
+// failing each one.
 //
 // Used in internal offline tooling only.
-func FetchRegistryVersions(bp BridgedProvider) (map[string]bool, bool) {
+func NewUpstreamVersionValidator(bp BridgedProvider) func(ReleaseTag) error {
+	fetch := sync.OnceValues(func() (map[string]bool, bool) {
+		available, ok := fetchRegistryVersions(bp)
+		if !ok {
+			fmt.Fprintf(os.Stderr,
+				"  Warning: cannot validate upstream versions for %s against the Terraform registry\n", bp)
+		}
+		return available, ok
+	})
+	return func(v ReleaseTag) error {
+		available, ok := fetch()
+		if ok && !available[strings.TrimPrefix(string(v), "v")] {
+			return fmt.Errorf("inferred upstream version %s is not available from the Terraform registry", v)
+		}
+		return nil
+	}
+}
+
+// fetchRegistryVersions returns the set of upstream provider versions (without the "v"
+// prefix) that the Terraform registry actually serves for the given bridged provider.
+// It returns ok=false when the provider has no registry.terraform.io mapping or the
+// registry could not be queried. When a provider maps from several registry addresses,
+// one successful fetch is enough for ok=true, so a partially failed fetch can yield an
+// incomplete set — acceptable because a human reviews the resulting versions.yaml diff.
+func fetchRegistryVersions(bp BridgedProvider) (map[string]bool, bool) {
 	var addrs []string
 	for addr, detail := range providerMapping {
 		s := string(addr)

--- a/pkg/providermap/versions.yaml
+++ b/pkg/providermap/versions.yaml
@@ -189,7 +189,7 @@ bridged:
         - pulumi: v4.5.0
           error: no GitHub release
         - pulumi: v4.4.0
-          upstream: v3.19.1
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.3.0
           error: no GitHub release
         - pulumi: v4.2.1
@@ -384,7 +384,7 @@ bridged:
         - pulumi: v2.8.0
           error: no GitHub release
         - pulumi: v2.7.0
-          upstream: v3.19.1
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v2.6.0
           error: no GitHub release
         - pulumi: v2.5.0
@@ -425,13 +425,13 @@ bridged:
         - pulumi: v3.104.0
           upstream: v1.282.0
         - pulumi: v3.103.0
-          upstream: v3.130.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v3.102.0
           upstream: v1.278.0
         - pulumi: v3.101.0
           upstream: v1.277.0
         - pulumi: v3.100.0
-          upstream: v3.127.0
+          upstream: v1.276.0
         - pulumi: v3.99.0
           upstream: v1.275.0
         - pulumi: v3.98.0
@@ -475,7 +475,7 @@ bridged:
         - pulumi: v3.81.0
           upstream: v1.252.0
         - pulumi: v3.80.0
-          upstream: v3.110.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v3.79.0
           upstream: v1.250.0
         - pulumi: v3.78.0
@@ -573,13 +573,13 @@ bridged:
         - pulumi: v3.45.0
           upstream: v1.213.0
         - pulumi: v3.44.2
-          upstream: v3.63.2
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v3.44.1
-          upstream: v3.62.0
+          upstream: v1.211.2
         - pulumi: v3.44.0
-          upstream: v3.60.1
+          upstream: v1.211.0
         - pulumi: v3.43.1
-          upstream: v3.59.0
+          upstream: v1.209.1
         - pulumi: v3.43.0
           upstream: v1.209.0
         - pulumi: v3.42.0
@@ -633,9 +633,9 @@ bridged:
         - pulumi: v3.19.0
           error: no GitHub release
         - pulumi: v3.18.0
-          upstream: v3.18.0
+          error: inferred upstream version v3.18.0 is not available from the Terraform registry
         - pulumi: v3.17.0
-          upstream: v3.19.1
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v3.16.0
           error: no GitHub release
         - pulumi: v3.15.0
@@ -849,11 +849,11 @@ bridged:
         - pulumi: v8.11.1
           upstream: v12.11.5
         - pulumi: v8.11.0
-          upstream: v3.130.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v8.10.5
           upstream: v12.11.4
         - pulumi: v8.10.4
-          upstream: v3.126.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v8.10.3
           upstream: v12.11.3
         - pulumi: v8.10.2
@@ -915,7 +915,7 @@ bridged:
         - pulumi: v8.1.0
           upstream: v12.1.0
         - pulumi: v8.0.1
-          upstream: v3.91.1
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v8.0.0
           upstream: v12.0.0
         - pulumi: v7.10.0
@@ -1025,7 +1025,7 @@ bridged:
         - pulumi: v5.4.2
           upstream: v9.7.3
         - pulumi: v5.4.1
-          upstream: v3.63.2
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v5.4.0
           upstream: v9.7.2
         - pulumi: v5.3.0
@@ -1115,7 +1115,7 @@ bridged:
         - pulumi: v0.7.0
           error: no GitHub release
         - pulumi: v0.6.0
-          upstream: v3.19.1
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v0.5.1
           upstream: v2.20.1
         - pulumi: v0.5.0
@@ -1236,7 +1236,7 @@ bridged:
         - pulumi: v3.8.3
           upstream: v1.7.3
         - pulumi: v3.8.2
-          upstream: v1.7.2
+          error: inferred upstream version v1.7.2 is not available from the Terraform registry
         - pulumi: v3.8.1
           upstream: v1.7.1
         - pulumi: v3.8.0
@@ -1276,7 +1276,7 @@ bridged:
         - pulumi: v2.24.3
           error: no GitHub release
         - pulumi: v2.24.2
-          upstream: v3.59.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v2.24.1
           upstream: v0.50.2
         - pulumi: v2.24.0
@@ -1288,7 +1288,7 @@ bridged:
         - pulumi: v2.21.0
           upstream: v0.48.0
         - pulumi: v2.20.0
-          upstream: v3.47.2
+          upstream: v0.47.0
         - pulumi: v2.19.0
           upstream: v0.46.0
         - pulumi: v2.18.0
@@ -1318,9 +1318,9 @@ bridged:
         - pulumi: v2.7.0
           error: no GitHub release
         - pulumi: v2.6.0
-          upstream: v3.19.1
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v2.5.0
-          upstream: v0.26.2
+          error: inferred upstream version v0.26.2 is not available from the Terraform registry
         - pulumi: v2.4.0
           error: no GitHub release
         - pulumi: v2.3.2
@@ -1467,7 +1467,7 @@ bridged:
         - pulumi: v6.82.1
           error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v6.82.0
-          upstream: v3.109.0
+          error: no GitHub release
         - pulumi: v6.81.0
           upstream: v5.98.0
         - pulumi: v6.80.0
@@ -1481,7 +1481,7 @@ bridged:
         - pulumi: v6.77.1
           error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v6.77.0
-          upstream: v3.106.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v6.76.0
           upstream: v5.94.1
         - pulumi: v6.75.0
@@ -1495,7 +1495,7 @@ bridged:
         - pulumi: v6.71.0
           upstream: v5.89.0
         - pulumi: v6.70.1
-          upstream: v3.104.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v6.70.0
           upstream: v5.88.0
         - pulumi: v6.69.0
@@ -1525,7 +1525,7 @@ bridged:
         - pulumi: v6.62.0
           upstream: v5.78.0
         - pulumi: v6.61.0
-          upstream: v3.96.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v6.60.0
           upstream: v5.76.0
         - pulumi: v6.59.2
@@ -1535,13 +1535,13 @@ bridged:
         - pulumi: v6.59.0
           error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v6.58.0
-          upstream: v3.94.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v6.57.0
           upstream: v5.73.0
         - pulumi: v6.56.1
           error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v6.56.0
-          upstream: v5.71.0
+          error: inferred upstream version v5.71.0 is not available from the Terraform registry
         - pulumi: v6.55.0
           error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v6.54.2
@@ -1551,19 +1551,19 @@ bridged:
         - pulumi: v6.54.0
           upstream: v5.69.0
         - pulumi: v6.53.0
-          upstream: v3.91.1
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v6.52.0
           upstream: v5.67.0
         - pulumi: v6.51.1
           error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v6.51.0
-          upstream: v3.90.0
+          upstream: v5.64.0
         - pulumi: v6.50.1
           upstream: v5.63.1
         - pulumi: v6.50.0
-          upstream: v3.89.1
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v6.49.1
-          upstream: v3.89.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v6.49.0
           upstream: v5.62.0
         - pulumi: v6.48.0
@@ -1573,7 +1573,7 @@ bridged:
         - pulumi: v6.46.0
           error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v6.45.2
-          upstream: v3.87.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v6.45.1
           error: no GitHub release
         - pulumi: v6.45.0
@@ -1581,11 +1581,11 @@ bridged:
         - pulumi: v6.44.0
           upstream: v5.57.0
         - pulumi: v6.43.0
-          upstream: v3.86.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v6.42.1
           error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v6.42.0
-          upstream: v3.85.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v6.41.0
           upstream: v5.54.1
         - pulumi: v6.40.0
@@ -1593,17 +1593,17 @@ bridged:
         - pulumi: v6.39.1
           error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v6.39.0
-          upstream: v3.84.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v6.38.1
           error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v6.38.0
           error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v6.37.1
-          upstream: v3.83.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v6.37.0
           error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v6.36.0
-          upstream: v3.82.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v6.35.0
           error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v6.34.1
@@ -1613,7 +1613,7 @@ bridged:
         - pulumi: v6.33.1
           error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v6.33.0
-          upstream: v3.81.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v6.32.0
           upstream: v5.46.0
         - pulumi: v6.31.1
@@ -1623,13 +1623,13 @@ bridged:
         - pulumi: v6.30.0
           error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v6.29.1
-          upstream: v3.80.0
+          error: inferred upstream version v1.0.16 is not available from the Terraform registry
         - pulumi: v6.29.0
           error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v6.28.2
-          upstream: v3.79.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v6.28.1
-          upstream: v3.78.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v6.28.0
           error: no GitHub release
         - pulumi: v6.27.0
@@ -1637,7 +1637,7 @@ bridged:
         - pulumi: v6.26.0
           upstream: v5.40.0
         - pulumi: v6.25.1
-          upstream: v3.77.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v6.25.0
           upstream: v5.39.1
         - pulumi: v6.24.2
@@ -1703,7 +1703,7 @@ bridged:
         - pulumi: v6.7.0
           upstream: v5.23.1
         - pulumi: v6.6.1
-          upstream: v3.63.1
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v6.6.0
           upstream: v5.21.0
         - pulumi: v6.5.0
@@ -1729,13 +1729,13 @@ bridged:
         - pulumi: v5.43.0
           error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v5.42.0
-          upstream: v3.49.1
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v5.41.0
           upstream: v4.67.0
         - pulumi: v5.40.0
           error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v5.39.0
-          upstream: v3.45.3
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v5.38.0
           upstream: v4.64.0
         - pulumi: v5.37.0
@@ -1847,7 +1847,7 @@ bridged:
         - pulumi: v4.38.1
           error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.38.0
-          upstream: v3.19.1
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.37.5
           upstream: v3.74.3
         - pulumi: v4.37.4
@@ -2602,7 +2602,7 @@ bridged:
         - pulumi: v5.10.0
           error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v5.9.0
-          upstream: v3.24.1
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v5.8.0
           error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v5.7.0
@@ -2993,11 +2993,11 @@ bridged:
         - pulumi: v6.10.0
           upstream: v3.9.0
         - pulumi: v6.9.1
-          upstream: v3.130.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v6.9.0
           upstream: v3.8.0
         - pulumi: v6.8.1
-          upstream: v3.122.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v6.8.0
           upstream: v3.7.0
         - pulumi: v6.7.0
@@ -3005,7 +3005,7 @@ bridged:
         - pulumi: v6.6.0
           upstream: v3.5.0
         - pulumi: v6.5.2
-          upstream: v3.111.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v6.5.1
           upstream: v3.4.0
         - pulumi: v6.5.0
@@ -3017,9 +3017,9 @@ bridged:
         - pulumi: v6.2.0
           upstream: v3.1.0
         - pulumi: v6.1.0
-          upstream: v3.101.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v6.0.2
-          upstream: v3.97.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v6.0.1
           upstream: v3.0.2
         - pulumi: v6.0.0
@@ -3035,7 +3035,7 @@ bridged:
         - pulumi: v5.53.5
           error: no GitHub release
         - pulumi: v5.53.4
-          upstream: v3.91.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v5.53.3
           error: no GitHub release
         - pulumi: v5.53.2
@@ -3059,19 +3059,19 @@ bridged:
         - pulumi: v5.47.2
           error: no GitHub release
         - pulumi: v5.47.1
-          upstream: v3.74.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v5.47.0
           upstream: v2.47.0
         - pulumi: v5.46.0
           error: no GitHub release
         - pulumi: v5.45.0
-          upstream: v3.65.0
+          upstream: v2.46.0
         - pulumi: v5.44.0
           upstream: v2.45.0
         - pulumi: v5.43.0
-          upstream: v3.62.0
+          upstream: v2.44.0
         - pulumi: v5.42.0
-          upstream: v3.60.1
+          upstream: v2.43.0
         - pulumi: v5.41.0
           upstream: v2.42.0
         - pulumi: v5.40.0
@@ -3125,7 +3125,7 @@ bridged:
         - pulumi: v5.19.0
           upstream: v2.2.0
         - pulumi: v5.18.0
-          upstream: v3.19.1
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v5.17.0
           upstream: v2.18.0
         - pulumi: v5.16.0
@@ -3288,9 +3288,9 @@ bridged:
         - pulumi: v3.2.0
           upstream: v1.2.0
         - pulumi: v3.1.3
-          upstream: v3.88.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v3.1.2
-          upstream: v3.87.0
+          error: no GitHub release
         - pulumi: v3.1.1
           upstream: v1.1.1
         - pulumi: v3.1.0
@@ -3308,7 +3308,7 @@ bridged:
         - pulumi: v2.14.0
           upstream: v0.10.0
         - pulumi: v2.13.0
-          upstream: v3.59.0
+          upstream: v0.9.1
         - pulumi: v2.12.0
           upstream: v0.9.0
         - pulumi: v2.11.0
@@ -3377,7 +3377,7 @@ bridged:
         - pulumi: v3.28.1
           upstream: v1.44.3
         - pulumi: v3.28.0
-          upstream: v1.44.2
+          error: inferred upstream version v1.44.2 is not available from the Terraform registry
         - pulumi: v3.27.1
           upstream: v1.43.1
         - pulumi: v3.27.0
@@ -3395,7 +3395,7 @@ bridged:
         - pulumi: v3.24.2
           upstream: v1.38.2
         - pulumi: v3.24.1
-          upstream: v3.117.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v3.24.0
           upstream: v1.36.0
         - pulumi: v3.23.0
@@ -3423,7 +3423,7 @@ bridged:
         - pulumi: v3.18.0
           upstream: v1.30.0
         - pulumi: v3.17.6
-          upstream: v3.84.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v3.17.5
           upstream: v1.29.5
         - pulumi: v3.17.4
@@ -3437,7 +3437,7 @@ bridged:
         - pulumi: v3.17.0
           upstream: v1.29.0
         - pulumi: v3.16.0
-          upstream: v3.60.1
+          upstream: v1.28.0
         - pulumi: v3.15.2
           upstream: v1.27.1
         - pulumi: v3.15.1
@@ -3606,7 +3606,7 @@ bridged:
         - pulumi: v5.47.0
           upstream: v4.50.0
         - pulumi: v5.46.0
-          upstream: v3.99.0
+          upstream: v4.49.1
         - pulumi: v5.45.0
           upstream: v4.48.0
         - pulumi: v5.44.0
@@ -3879,47 +3879,47 @@ bridged:
           error: no GitHub release
     cloudinit:
         - pulumi: v1.6.0
-          upstream: v3.130.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v1.5.0
           upstream: v2.4.0
         - pulumi: v1.4.17
-          upstream: v3.128.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v1.4.16
-          upstream: v3.122.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v1.4.15
-          upstream: v3.119.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v1.4.14
-          upstream: v3.115.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v1.4.13
-          upstream: v3.111.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v1.4.12
           upstream: v2.3.7
         - pulumi: v1.4.11
           upstream: v2.3.6
         - pulumi: v1.4.10
-          upstream: v3.103.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v1.4.9
-          upstream: v3.98.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v1.4.8
           error: no GitHub release
         - pulumi: v1.4.7
-          upstream: v3.91.1
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v1.4.6
           upstream: v2.3.5
         - pulumi: v1.4.5
           error: no GitHub release
         - pulumi: v1.4.4
-          upstream: v3.85.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v1.4.3
           upstream: v2.3.4
         - pulumi: v1.4.2
-          upstream: v3.81.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v1.4.1
           error: no GitHub release
         - pulumi: v1.4.0
           upstream: v2.3.3
         - pulumi: v1.3.1
-          upstream: v3.63.2
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v1.3.0
           error: no GitHub release
         - pulumi: v1.2.2
@@ -4217,25 +4217,25 @@ bridged:
           error: no GitHub release
     consul:
         - pulumi: v3.15.0
-          upstream: v3.130.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v3.14.1
-          upstream: v3.125.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v3.14.0
           upstream: v2.23.0
         - pulumi: v3.13.3
           upstream: v2.22.1
         - pulumi: v3.13.2
-          upstream: v3.116.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v3.13.1
-          upstream: v3.112.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v3.13.0
           upstream: v2.22.0
         - pulumi: v3.12.5
-          upstream: v3.107.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v3.12.4
-          upstream: v3.103.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v3.12.3
-          upstream: v3.98.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v3.12.2
           error: no GitHub release
         - pulumi: v3.12.1
@@ -4243,13 +4243,13 @@ bridged:
         - pulumi: v3.12.0
           upstream: v2.21.0
         - pulumi: v3.11.4
-          upstream: v3.88.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v3.11.3
-          upstream: v3.83.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v3.11.2
-          upstream: v3.78.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v3.11.1
-          upstream: v3.71.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v3.11.0
           upstream: v2.20.0
         - pulumi: v3.10.0
@@ -4313,7 +4313,7 @@ bridged:
         - pulumi: v2.0.0
           error: no GitHub release
         - pulumi: v1.8.0
-          error: 'failed to fetch v1.8.0: exit status 128'
+          error: no GitHub release
         - pulumi: v1.7.0
           error: no GitHub release
         - pulumi: v1.6.0
@@ -4346,7 +4346,7 @@ bridged:
         - pulumi: v1.94.0
           upstream: v1.116.0
         - pulumi: v1.93.0
-          upstream: v3.130.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v1.92.0
           upstream: v1.115.0
         - pulumi: v1.91.1
@@ -4444,9 +4444,9 @@ bridged:
         - pulumi: v1.51.0
           upstream: v1.53.0
         - pulumi: v1.50.2
-          upstream: v3.91.1
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v1.50.1
-          upstream: v3.91.1
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v1.50.0
           error: no GitHub release
         - pulumi: v1.49.0
@@ -4478,7 +4478,7 @@ bridged:
         - pulumi: v1.40.0
           upstream: v1.43.0
         - pulumi: v1.39.2
-          upstream: v3.82.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v1.39.1
           error: no GitHub release
         - pulumi: v1.39.0
@@ -4500,7 +4500,7 @@ bridged:
         - pulumi: v1.32.2
           upstream: v1.36.3
         - pulumi: v1.32.1
-          upstream: v3.74.0
+          upstream: v1.36.2
         - pulumi: v1.32.0
           upstream: v1.36.0
         - pulumi: v1.31.0
@@ -4518,17 +4518,17 @@ bridged:
         - pulumi: v1.26.0
           upstream: v1.29.0
         - pulumi: v1.25.0
-          upstream: v3.62.0
+          upstream: v1.28.1
         - pulumi: v1.24.0
-          upstream: v3.60.1
+          upstream: v1.27.0
         - pulumi: v1.23.0
-          upstream: v3.60.0
+          upstream: v1.26.0
         - pulumi: v1.22.1
           error: no GitHub release
         - pulumi: v1.22.0
           upstream: v1.24.0
         - pulumi: v1.21.0
-          upstream: v3.56.2
+          upstream: v1.23.0
         - pulumi: v1.20.0
           upstream: v1.22.0
         - pulumi: v1.19.0
@@ -4890,7 +4890,7 @@ bridged:
         - pulumi: v1.10.0
           upstream: v1.11.0
         - pulumi: v1.9.0
-          upstream: v3.130.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v1.8.2
           upstream: v1.10.4
         - pulumi: v1.8.1
@@ -4928,7 +4928,7 @@ bridged:
         - pulumi: v1.0.0
           error: no GitHub release
         - pulumi: v0.1.31
-          upstream: v3.109.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v0.1.30
           upstream: v0.3.26
         - pulumi: v0.1.29
@@ -4938,7 +4938,7 @@ bridged:
         - pulumi: v0.1.27
           upstream: v0.3.23
         - pulumi: v0.1.26
-          upstream: v3.100.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v0.1.25
           upstream: v0.3.22
         - pulumi: v0.1.24
@@ -5007,7 +5007,7 @@ bridged:
         - pulumi: v4.69.0
           upstream: v2.89.0
         - pulumi: v4.68.0
-          upstream: v3.130.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.67.0
           upstream: v2.87.0
         - pulumi: v4.66.0
@@ -5051,7 +5051,7 @@ bridged:
         - pulumi: v4.48.0
           upstream: v2.57.0
         - pulumi: v4.47.0
-          upstream: v2.56.0
+          error: inferred upstream version v2.56.0 is not available from the Terraform registry
         - pulumi: v4.46.0
           upstream: v2.55.0
         - pulumi: v4.45.0
@@ -5310,7 +5310,7 @@ bridged:
           error: no GitHub release
     dnsimple:
         - pulumi: v5.2.0
-          upstream: v3.130.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v5.1.2
           upstream: v2.1.2
         - pulumi: v5.1.1
@@ -5318,17 +5318,17 @@ bridged:
         - pulumi: v5.1.0
           upstream: v2.1.0
         - pulumi: v5.0.3
-          upstream: v3.128.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v5.0.2
-          upstream: v3.123.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v5.0.1
           upstream: v2.0.1
         - pulumi: v5.0.0
           upstream: v2.0.0
         - pulumi: v4.4.2
-          upstream: v3.117.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.4.1
-          upstream: v3.114.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.4.0
           upstream: v1.10.0
         - pulumi: v4.3.2
@@ -5340,15 +5340,15 @@ bridged:
         - pulumi: v4.2.3
           error: no GitHub release
         - pulumi: v4.2.2
-          upstream: v3.104.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.2.1
-          upstream: v3.99.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.2.0
           upstream: v1.8.0
         - pulumi: v4.1.3
           error: no GitHub release
         - pulumi: v4.1.2
-          upstream: v3.91.1
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.1.1
           error: no GitHub release
         - pulumi: v4.1.0
@@ -5358,11 +5358,11 @@ bridged:
         - pulumi: v3.5.0
           upstream: v0.17.0
         - pulumi: v3.4.3
-          upstream: v3.83.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v3.4.2
-          upstream: v3.78.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v3.4.1
-          upstream: v3.71.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v3.4.0
           upstream: v0.15.0
         - pulumi: v3.3.0
@@ -5435,9 +5435,9 @@ bridged:
         - pulumi: v5.0.0
           upstream: v4.2.0
         - pulumi: v4.11.2
-          upstream: v3.125.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.11.1
-          upstream: v3.123.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.11.0
           upstream: v3.9.0
         - pulumi: v4.10.0
@@ -5447,43 +5447,43 @@ bridged:
         - pulumi: v4.8.2
           error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.8.1
-          upstream: v3.112.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.8.0
           upstream: v3.6.2
         - pulumi: v4.7.0
-          upstream: v3.108.0
+          upstream: v3.5.0
         - pulumi: v4.6.2
-          upstream: v3.105.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.6.1
-          upstream: v3.101.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.6.0
-          upstream: v3.100.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.5.8
-          upstream: v3.98.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.5.7
-          upstream: v3.92.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.5.6
-          upstream: v3.91.1
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.5.5
-          upstream: v3.88.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.5.4
-          upstream: v3.83.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.5.3
           error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.5.2
-          upstream: v3.78.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.5.1
-          upstream: v3.71.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.5.0
-          upstream: v3.65.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.4.5
-          upstream: v3.63.2
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.4.4
           error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.4.3
           error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.4.2
-          upstream: v3.59.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.4.1
           error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.4.0
@@ -5493,7 +5493,7 @@ bridged:
         - pulumi: v4.3.1
           error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.3.0
-          upstream: v3.50.1
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.2.4
           error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.2.3
@@ -5501,7 +5501,7 @@ bridged:
         - pulumi: v4.2.2
           error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.2.1
-          upstream: v3.47.2
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.2.0
           error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.1.2
@@ -5618,25 +5618,25 @@ bridged:
         - pulumi: v0.12.2
           error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v0.12.1
-          upstream: v3.133.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v0.12.0
-          upstream: v3.130.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v0.11.0
           upstream: v0.13.0
         - pulumi: v0.10.11
           upstream: v0.12.5
         - pulumi: v0.10.10
-          upstream: v3.122.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v0.10.9
           upstream: v0.12.4
         - pulumi: v0.10.8
-          upstream: v3.115.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v0.10.7
-          upstream: v3.111.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v0.10.6
-          upstream: v3.107.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v0.10.5
-          upstream: v3.103.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v0.10.4
           upstream: v0.12.2
         - pulumi: v0.10.3
@@ -5648,23 +5648,23 @@ bridged:
         - pulumi: v0.10.0
           upstream: v0.12.0
         - pulumi: v0.9.2
-          upstream: v3.91.1
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v0.9.1
           error: no GitHub release
         - pulumi: v0.9.0
           upstream: v0.11.0
         - pulumi: v0.8.2
-          upstream: v3.89.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v0.8.1
-          upstream: v3.84.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v0.8.0
           upstream: v0.10.0
         - pulumi: v0.7.2
-          upstream: v3.78.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v0.7.1
-          upstream: v3.71.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v0.7.0
-          upstream: v3.60.1
+          upstream: v0.9.0
         - pulumi: v0.6.0
           upstream: v0.8.0
         - pulumi: v0.5.1
@@ -5744,7 +5744,7 @@ bridged:
         - pulumi: v3.19.2
           upstream: v1.24.1
         - pulumi: v3.19.1
-          upstream: v3.115.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v3.19.0
           upstream: v1.24.0
         - pulumi: v3.18.0
@@ -5770,7 +5770,7 @@ bridged:
         - pulumi: v3.17.2
           upstream: v1.22.2
         - pulumi: v3.17.1
-          upstream: v3.82.0
+          upstream: v1.22.1
         - pulumi: v3.17.0
           upstream: v1.22.0
         - pulumi: v3.16.0
@@ -5780,11 +5780,11 @@ bridged:
         - pulumi: v3.15.2
           upstream: v1.20.1
         - pulumi: v3.15.1
-          upstream: v3.63.2
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v3.15.0
           error: no GitHub release
         - pulumi: v3.14.0
-          upstream: v3.61.0
+          upstream: v1.20.0
         - pulumi: v3.13.0
           error: no GitHub release
         - pulumi: v3.12.1
@@ -5792,7 +5792,7 @@ bridged:
         - pulumi: v3.12.0
           upstream: v1.18.0
         - pulumi: v3.11.1
-          upstream: v3.49.0
+          upstream: v1.17.1
         - pulumi: v3.11.0
           upstream: v1.17.0
         - pulumi: v3.10.1
@@ -5804,7 +5804,7 @@ bridged:
         - pulumi: v3.8.0
           error: no GitHub release
         - pulumi: v3.7.0
-          upstream: v3.19.3
+          upstream: v1.13.0
         - pulumi: v3.6.1
           error: no GitHub release
         - pulumi: v3.6.0
@@ -5915,7 +5915,7 @@ bridged:
         - pulumi: v12.2.1
           upstream: v9.2.1
         - pulumi: v12.2.0
-          upstream: v3.130.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v12.1.0
           upstream: v9.2.0
         - pulumi: v12.0.1
@@ -5937,7 +5937,7 @@ bridged:
         - pulumi: v11.0.0
           upstream: v8.0.0
         - pulumi: v10.1.1
-          upstream: v3.112.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v10.1.0
           upstream: v7.1.0
         - pulumi: v10.0.0
@@ -5949,7 +5949,7 @@ bridged:
         - pulumi: v8.14.0
           upstream: v5.16.0
         - pulumi: v8.13.1
-          upstream: v3.100.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v8.13.0
           upstream: v5.15.0
         - pulumi: v8.12.2
@@ -5981,9 +5981,9 @@ bridged:
         - pulumi: v8.5.0
           upstream: v5.7.0
         - pulumi: v8.4.2
-          upstream: v3.71.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v8.4.1
-          upstream: v3.63.2
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v8.4.0
           upstream: v5.6.0
         - pulumi: v8.3.0
@@ -6031,7 +6031,7 @@ bridged:
         - pulumi: v4.0.3
           error: no GitHub release
         - pulumi: v4.0.2
-          upstream: v2.10.1
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.0.1
           upstream: v1.1.2
         - pulumi: v4.0.0
@@ -6540,7 +6540,7 @@ bridged:
         - pulumi: v6.14.0
           upstream: v4.12.0
         - pulumi: v6.13.0
-          upstream: v3.19.1
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v6.12.0
           error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v6.11.0
@@ -6967,7 +6967,7 @@ bridged:
         - pulumi: v5.14.1
           upstream: v5.30.1
         - pulumi: v5.14.0
-          upstream: v5.30.0
+          error: inferred upstream version v5.30.0 is not available from the Terraform registry
         - pulumi: v5.13.0
           upstream: v5.29.0
         - pulumi: v5.12.1
@@ -7015,7 +7015,7 @@ bridged:
         - pulumi: v4.13.0
           error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.12.0
-          upstream: v3.21.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.11.0
           upstream: v4.30.0
         - pulumi: v4.10.1
@@ -7351,7 +7351,7 @@ bridged:
         - pulumi: v0.13.1
           upstream: v0.42.8
         - pulumi: v0.13.0
-          upstream: v3.130.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v0.12.1
           upstream: v0.42.7
         - pulumi: v0.12.0
@@ -7504,7 +7504,7 @@ bridged:
         - pulumi: v1.38.0
           upstream: v1.64.0
         - pulumi: v1.37.0
-          upstream: v3.130.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v1.36.0
           error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v1.35.0
@@ -7514,7 +7514,7 @@ bridged:
         - pulumi: v1.33.0
           upstream: v1.61.0
         - pulumi: v1.32.2
-          upstream: v3.127.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v1.32.1
           upstream: v1.60.1
         - pulumi: v1.32.0
@@ -7536,7 +7536,7 @@ bridged:
         - pulumi: v1.24.0
           upstream: v1.52.0
         - pulumi: v1.23.1
-          upstream: v3.111.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v1.23.0
           upstream: v1.51.0
         - pulumi: v1.22.1
@@ -7544,7 +7544,7 @@ bridged:
         - pulumi: v1.22.0
           upstream: v1.50.0
         - pulumi: v1.21.2
-          upstream: v3.102.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v1.21.1
           upstream: v1.49.1
         - pulumi: v1.21.0
@@ -7552,17 +7552,17 @@ bridged:
         - pulumi: v1.20.5
           error: no GitHub release
         - pulumi: v1.20.4
-          upstream: v3.91.1
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v1.20.3
-          upstream: v3.91.1
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v1.20.2
-          upstream: v3.91.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v1.20.1
           upstream: v1.48.1
         - pulumi: v1.20.0
           upstream: v1.48.0
         - pulumi: v1.19.2
-          upstream: v3.87.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v1.19.1
           error: no GitHub release
         - pulumi: v1.19.0
@@ -7570,19 +7570,19 @@ bridged:
         - pulumi: v1.18.1
           upstream: v1.46.1
         - pulumi: v1.18.0
-          upstream: v1.46.0
+          error: inferred upstream version v1.46.0 is not available from the Terraform registry
         - pulumi: v1.17.1
-          upstream: v3.77.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v1.17.0
           upstream: v1.45.0
         - pulumi: v1.16.2
-          upstream: v3.63.2
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v1.16.1
           upstream: v1.44.1
         - pulumi: v1.16.0
-          upstream: v3.61.0
+          upstream: v1.44.0
         - pulumi: v1.15.0
-          upstream: v3.60.1
+          upstream: v1.43.0
         - pulumi: v1.14.1
           upstream: v1.42.1
         - pulumi: v1.14.0
@@ -7590,7 +7590,7 @@ bridged:
         - pulumi: v1.13.0
           upstream: v1.41.0
         - pulumi: v1.12.1
-          upstream: v3.49.1
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v1.12.0
           upstream: v1.39.0
         - pulumi: v1.11.1
@@ -7779,9 +7779,9 @@ bridged:
         - pulumi: v0.10.0
           upstream: v0.8.0
         - pulumi: v0.9.0
-          upstream: v3.130.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v0.8.2
-          upstream: v3.126.0
+          upstream: v0.7.2
         - pulumi: v0.8.1
           upstream: v0.7.1
         - pulumi: v0.8.0
@@ -7795,7 +7795,7 @@ bridged:
         - pulumi: v0.7.0
           upstream: v0.6.0
         - pulumi: v0.6.4
-          upstream: v3.117.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v0.6.3
           upstream: v0.5.3
         - pulumi: v0.6.2
@@ -7912,13 +7912,13 @@ bridged:
           error: no GitHub release
     kafka:
         - pulumi: v3.13.0
-          upstream: v3.130.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v3.12.4
-          upstream: v3.126.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v3.12.3
-          upstream: v3.119.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v3.12.2
-          upstream: v3.118.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v3.12.1
           upstream: v0.13.1
         - pulumi: v3.12.0
@@ -7936,11 +7936,11 @@ bridged:
         - pulumi: v3.10.0
           upstream: v0.10.1
         - pulumi: v3.9.1
-          upstream: v3.108.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v3.9.0
           upstream: v0.9.0
         - pulumi: v3.8.3
-          upstream: v3.103.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v3.8.2
           upstream: v0.8.3
         - pulumi: v3.8.1
@@ -7948,7 +7948,7 @@ bridged:
         - pulumi: v3.8.0
           upstream: v0.8.1
         - pulumi: v3.7.5
-          upstream: v3.87.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v3.7.4
           error: no GitHub release
         - pulumi: v3.7.3
@@ -7962,7 +7962,7 @@ bridged:
         - pulumi: v3.6.0
           upstream: v0.6.0
         - pulumi: v3.5.1
-          upstream: v3.71.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v3.5.0
           error: no GitHub release
         - pulumi: v3.4.0
@@ -8045,41 +8045,41 @@ bridged:
           error: no GitHub release
     keycloak:
         - pulumi: v6.12.0
-          upstream: v5.8.0
+          error: inferred upstream version v5.8.0 is not available from the Terraform registry
         - pulumi: v6.11.0
-          upstream: v5.7.0
+          error: inferred upstream version v5.7.0 is not available from the Terraform registry
         - pulumi: v6.10.1
-          upstream: v5.7.0
+          error: inferred upstream version v5.7.0 is not available from the Terraform registry
         - pulumi: v6.10.0
-          upstream: v5.7.0
+          error: inferred upstream version v5.7.0 is not available from the Terraform registry
         - pulumi: v6.9.0
-          upstream: v5.6.0
+          error: inferred upstream version v5.6.0 is not available from the Terraform registry
         - pulumi: v6.8.0
-          upstream: v5.5.0
+          error: inferred upstream version v5.5.0 is not available from the Terraform registry
         - pulumi: v6.7.1
-          upstream: v5.4.0
+          error: inferred upstream version v5.4.0 is not available from the Terraform registry
         - pulumi: v6.7.0
-          upstream: v5.4.0
+          error: inferred upstream version v5.4.0 is not available from the Terraform registry
         - pulumi: v6.6.0
-          upstream: v5.3.0
+          error: inferred upstream version v5.3.0 is not available from the Terraform registry
         - pulumi: v6.5.0
-          upstream: v5.2.0
+          error: inferred upstream version v5.2.0 is not available from the Terraform registry
         - pulumi: v6.4.0
-          upstream: v5.2.0
+          error: inferred upstream version v5.2.0 is not available from the Terraform registry
         - pulumi: v6.3.0
-          upstream: v5.2.0
+          error: inferred upstream version v5.2.0 is not available from the Terraform registry
         - pulumi: v6.2.2
-          upstream: v5.1.1
+          error: inferred upstream version v5.1.1 is not available from the Terraform registry
         - pulumi: v6.2.1
-          upstream: v5.1.1
+          error: inferred upstream version v5.1.1 is not available from the Terraform registry
         - pulumi: v6.2.0
-          upstream: v5.1.0
+          error: inferred upstream version v5.1.0 is not available from the Terraform registry
         - pulumi: v6.1.0
-          upstream: v5.0.0
+          error: inferred upstream version v5.0.0 is not available from the Terraform registry
         - pulumi: v6.0.0
-          upstream: v4.5.0
+          error: inferred upstream version v4.5.0 is not available from the Terraform registry
         - pulumi: v5.4.0
-          upstream: v4.5.0
+          error: inferred upstream version v4.5.0 is not available from the Terraform registry
         - pulumi: v5.3.5
           upstream: v4.4.0
         - pulumi: v5.3.4
@@ -8180,35 +8180,35 @@ bridged:
           error: no GitHub release
     kong:
         - pulumi: v4.6.0
-          upstream: v3.130.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.5.14
-          upstream: v3.128.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.5.13
-          upstream: v3.122.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.5.12
-          upstream: v3.119.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.5.11
-          upstream: v3.115.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.5.10
-          upstream: v3.111.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.5.9
-          upstream: v3.107.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.5.8
-          upstream: v3.103.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.5.7
-          upstream: v3.98.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.5.6
           error: no GitHub release
         - pulumi: v4.5.5
-          upstream: v3.90.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.5.4
-          upstream: v3.85.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.5.3
           upstream: v6.5.1
         - pulumi: v4.5.2
-          upstream: v3.78.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.5.1
-          upstream: v3.71.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.5.0
           upstream: v6.5.0
         - pulumi: v4.4.1
@@ -8283,7 +8283,7 @@ bridged:
         - pulumi: v5.7.0
           upstream: v3.8.0
         - pulumi: v5.6.0
-          upstream: v3.118.0
+          upstream: v3.7.0
         - pulumi: v5.5.0
           upstream: v3.5.1
         - pulumi: v5.4.0
@@ -8333,7 +8333,7 @@ bridged:
         - pulumi: v4.28.0
           upstream: v2.29.0
         - pulumi: v4.27.2
-          upstream: v3.91.1
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.27.1
           error: no GitHub release
         - pulumi: v4.27.0
@@ -8631,31 +8631,31 @@ bridged:
           error: no GitHub release
     meraki:
         - pulumi: v0.5.0
-          upstream: v3.130.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v0.4.7
-          upstream: v3.128.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v0.4.6
-          upstream: v3.122.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v0.4.5
-          upstream: v3.119.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v0.4.4
           error: no GitHub release
         - pulumi: v0.4.3
           error: no GitHub release
         - pulumi: v0.4.2
-          upstream: v3.109.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v0.4.1
-          upstream: v3.105.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v0.4.0
           error: no GitHub release
         - pulumi: v0.3.4
-          upstream: v3.98.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v0.3.3
           error: no GitHub release
         - pulumi: v0.3.2
           error: no GitHub release
         - pulumi: v0.3.1
-          upstream: v3.89.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v0.3.0
           upstream: v0.2.10-alpha
         - pulumi: v0.2.10
@@ -8688,43 +8688,43 @@ bridged:
           error: no GitHub release
     minio:
         - pulumi: v0.17.0
-          upstream: v3.130.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v0.16.9
-          upstream: v3.128.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v0.16.8
-          upstream: v3.122.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v0.16.7
-          upstream: v3.119.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v0.16.6
-          upstream: v3.115.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v0.16.5
-          upstream: v3.111.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v0.16.4
-          upstream: v3.107.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v0.16.3
-          upstream: v3.103.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v0.16.2
-          upstream: v3.97.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v0.16.1
-          upstream: v3.92.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v0.16.0
           error: no GitHub release
         - pulumi: v0.15.4
-          upstream: v3.85.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v0.15.3
-          upstream: v3.81.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v0.15.2
-          upstream: v3.75.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v0.15.1
           upstream: v1.20.1
         - pulumi: v0.15.0
           upstream: v1.19.0
         - pulumi: v0.14.3
-          upstream: v3.62.0
+          upstream: v1.18.3
         - pulumi: v0.14.2
-          upstream: v1.18.2
+          error: inferred upstream version v1.18.2 is not available from the Terraform registry
         - pulumi: v0.14.1
-          upstream: v3.60.1
+          error: inferred upstream version v1.18.1 is not available from the Terraform registry
         - pulumi: v0.14.0
           upstream: v1.18.0
         - pulumi: v0.13.2
@@ -8767,7 +8767,7 @@ bridged:
         - pulumi: v4.11.0
           upstream: v2.13.0
         - pulumi: v4.10.0
-          upstream: v3.130.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.9.0
           upstream: v2.12.0
         - pulumi: v4.8.0
@@ -8789,11 +8789,11 @@ bridged:
         - pulumi: v4.0.0
           upstream: v2.3.0
         - pulumi: v3.38.0
-          upstream: v3.118.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v3.37.0
           upstream: v1.41.0
         - pulumi: v3.36.1
-          upstream: v3.116.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v3.36.0
           upstream: v1.40.0
         - pulumi: v3.35.0
@@ -8839,7 +8839,7 @@ bridged:
         - pulumi: v3.20.0
           upstream: v1.21.0
         - pulumi: v3.19.1
-          upstream: v3.91.1
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v3.19.0
           upstream: v1.20.0
         - pulumi: v3.18.1
@@ -8891,7 +8891,7 @@ bridged:
         - pulumi: v3.11.1
           upstream: v1.12.2
         - pulumi: v3.11.0
-          upstream: v3.60.1
+          upstream: v1.12.1
         - pulumi: v3.10.1
           upstream: v1.11.1
         - pulumi: v3.10.0
@@ -8903,7 +8903,7 @@ bridged:
         - pulumi: v3.9.0
           upstream: v1.10.0
         - pulumi: v3.8.1
-          upstream: v3.49.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v3.8.0
           error: no GitHub release
         - pulumi: v3.7.2
@@ -9421,41 +9421,41 @@ bridged:
         - pulumi: v2.6.0
           upstream: v2.6.0
         - pulumi: v2.5.5
-          upstream: v3.122.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v2.5.4
           upstream: v2.5.2
         - pulumi: v2.5.3
           upstream: v2.5.1
         - pulumi: v2.5.2
-          upstream: v3.115.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v2.5.1
-          upstream: v3.111.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v2.5.0
           upstream: v2.5.0
         - pulumi: v2.4.3
-          upstream: v3.105.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v2.4.2
-          upstream: v3.100.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v2.4.1
           error: no GitHub release
         - pulumi: v2.4.0
           upstream: v2.4.0
         - pulumi: v2.3.3
-          upstream: v3.92.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v2.3.2
           upstream: v2.3.1
         - pulumi: v2.3.1
-          upstream: v3.89.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v2.3.0
           upstream: v2.3.0
         - pulumi: v2.2.1
-          upstream: v3.82.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v2.2.0
           upstream: v2.2.0
         - pulumi: v2.1.0
           upstream: v2.1.1
         - pulumi: v2.0.1
-          upstream: v3.71.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v2.0.0
           upstream: v2.0.0
         - pulumi: v0.4.1
@@ -9536,9 +9536,9 @@ bridged:
         - pulumi: v3.2.0
           upstream: v2.2.0
         - pulumi: v3.1.5
-          upstream: v3.71.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v3.1.4
-          upstream: v3.63.2
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v3.1.3
           upstream: v2.0.10
         - pulumi: v3.1.2
@@ -9762,7 +9762,7 @@ bridged:
         - pulumi: v2.19.0
           upstream: v6.20.0
         - pulumi: v2.18.0
-          upstream: v3.96.0
+          upstream: v6.19.0
         - pulumi: v2.17.0
           upstream: v6.18.0
         - pulumi: v2.16.0
@@ -9850,13 +9850,13 @@ bridged:
         - pulumi: v1.17.0
           upstream: v5.23.0
         - pulumi: v1.16.1
-          upstream: v3.66.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v1.16.0
           upstream: v5.19.0
         - pulumi: v1.15.0
           upstream: v5.18.0
         - pulumi: v1.14.0
-          upstream: v3.63.1
+          upstream: v5.17.0
         - pulumi: v1.13.0
           upstream: v5.16.0
         - pulumi: v1.12.0
@@ -9888,7 +9888,7 @@ bridged:
         - pulumi: v1.0.0
           upstream: v5.0.0
         - pulumi: v0.20.1
-          upstream: v3.49.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v0.20.0
           upstream: v4.123.0
         - pulumi: v0.19.0
@@ -9937,7 +9937,7 @@ bridged:
         - pulumi: v6.8.0
           upstream: v6.12.0
         - pulumi: v6.7.0
-          upstream: v3.130.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v6.6.0
           upstream: v6.10.0
         - pulumi: v6.5.0
@@ -9981,7 +9981,7 @@ bridged:
         - pulumi: v4.14.1
           upstream: v4.14.1
         - pulumi: v4.14.0
-          upstream: v3.103.0
+          upstream: v4.14.0
         - pulumi: v4.13.1
           upstream: v4.13.1
         - pulumi: v4.13.0
@@ -9997,7 +9997,7 @@ bridged:
         - pulumi: v4.11.0
           upstream: v4.11.0
         - pulumi: v4.10.1
-          upstream: v3.89.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.10.0
           upstream: v4.10.0
         - pulumi: v4.9.2
@@ -10015,7 +10015,7 @@ bridged:
         - pulumi: v4.7.0
           upstream: v4.7.0
         - pulumi: v4.6.3
-          upstream: v3.72.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.6.2
           upstream: v4.6.3
         - pulumi: v4.6.1
@@ -10023,7 +10023,7 @@ bridged:
         - pulumi: v4.6.0
           upstream: v4.6.0
         - pulumi: v4.5.1
-          upstream: v3.63.2
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.5.0
           upstream: v4.5.0
         - pulumi: v4.4.1
@@ -10186,15 +10186,15 @@ bridged:
           error: no GitHub release
     openstack:
         - pulumi: v5.5.0
-          upstream: v3.130.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v5.4.2
-          upstream: v3.126.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v5.4.1
-          upstream: v3.120.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v5.4.0
           upstream: v3.4.0
         - pulumi: v5.3.3
-          upstream: v3.114.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v5.3.2
           upstream: v3.3.2
         - pulumi: v5.3.1
@@ -10206,11 +10206,11 @@ bridged:
         - pulumi: v5.1.0
           upstream: v3.1.0
         - pulumi: v5.0.4
-          upstream: v3.107.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v5.0.3
-          upstream: v3.103.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v5.0.2
-          upstream: v3.98.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v5.0.1
           error: no GitHub release
         - pulumi: v5.0.0
@@ -10224,17 +10224,17 @@ bridged:
         - pulumi: v4.1.0
           upstream: v2.1.0
         - pulumi: v4.0.1
-          upstream: v3.87.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.0.0
           upstream: v2.0.0
         - pulumi: v3.15.2
-          upstream: v3.79.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v3.15.1
           upstream: v1.54.1
         - pulumi: v3.15.0
           upstream: v1.54.0
         - pulumi: v3.14.1
-          upstream: v3.71.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v3.14.0
           upstream: v1.53.0
         - pulumi: v3.13.3
@@ -10391,25 +10391,25 @@ bridged:
           error: no GitHub release
     opsgenie:
         - pulumi: v1.4.0
-          upstream: v3.130.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v1.3.21
-          upstream: v3.128.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v1.3.20
-          upstream: v3.122.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v1.3.19
-          upstream: v3.119.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v1.3.18
           upstream: v0.6.40
         - pulumi: v1.3.17
-          upstream: v3.115.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v1.3.16
-          upstream: v3.111.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v1.3.15
-          upstream: v3.107.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v1.3.14
-          upstream: v3.103.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v1.3.13
-          upstream: v3.98.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v1.3.12
           error: no GitHub release
         - pulumi: v1.3.11
@@ -10419,23 +10419,23 @@ bridged:
         - pulumi: v1.3.9
           upstream: v0.6.36
         - pulumi: v1.3.8
-          upstream: v3.85.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v1.3.7
-          upstream: v3.81.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v1.3.6
-          upstream: v3.76.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v1.3.5
-          upstream: v3.75.0
+          error: no GitHub release
         - pulumi: v1.3.4
           upstream: v0.6.35
         - pulumi: v1.3.3
           upstream: v0.6.34
         - pulumi: v1.3.2
-          upstream: v3.63.2
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v1.3.1
-          upstream: v3.62.0
+          upstream: v0.6.33
         - pulumi: v1.3.0
-          upstream: v3.60.1
+          upstream: v0.6.30
         - pulumi: v1.2.9
           upstream: v0.6.29
         - pulumi: v1.2.8
@@ -10445,7 +10445,7 @@ bridged:
         - pulumi: v1.2.6
           upstream: v0.6.25
         - pulumi: v1.2.5
-          upstream: v3.49.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v1.2.4
           upstream: v0.6.23
         - pulumi: v1.2.3
@@ -11009,7 +11009,7 @@ bridged:
           error: no GitHub release
     rancher2:
         - pulumi: v12.1.0
-          upstream: v3.130.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v12.0.1
           upstream: v14.1.1
         - pulumi: v12.0.0
@@ -11017,7 +11017,7 @@ bridged:
         - pulumi: v11.1.0
           upstream: v13.2.0
         - pulumi: v11.0.1
-          upstream: v3.122.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v11.0.0
           upstream: v13.1.4
         - pulumi: v10.3.0
@@ -11049,7 +11049,7 @@ bridged:
         - pulumi: v8.1.0
           upstream: v6.1.0
         - pulumi: v8.0.1
-          upstream: v3.102.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v8.0.0
           upstream: v6.0.0
         - pulumi: v7.1.2
@@ -11061,21 +11061,21 @@ bridged:
         - pulumi: v7.0.0
           upstream: v5.0.0
         - pulumi: v6.2.1
-          upstream: v3.89.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v6.2.0
           upstream: v4.2.0
         - pulumi: v6.1.1
-          upstream: v3.82.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v6.1.0
           upstream: v4.1.0
         - pulumi: v6.0.0
           upstream: v4.0.0
         - pulumi: v5.2.2
-          upstream: v3.71.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v5.2.1
-          upstream: v3.63.2
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v5.2.0
-          upstream: v3.62.0
+          upstream: v3.2.0
         - pulumi: v5.1.1
           upstream: v3.1.1
         - pulumi: v5.1.0
@@ -11170,39 +11170,39 @@ bridged:
           error: no GitHub release
     random:
         - pulumi: v4.21.0
-          upstream: v3.130.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.20.0
           upstream: v3.9.0
         - pulumi: v4.19.2
-          upstream: v3.125.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.19.1
           upstream: v3.8.1
         - pulumi: v4.19.0
           upstream: v3.8.0
         - pulumi: v4.18.5
-          upstream: v3.119.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.18.4
-          upstream: v3.115.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.18.3
-          upstream: v3.111.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.18.2
-          upstream: v3.107.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.18.1
           upstream: v3.7.2
         - pulumi: v4.18.0
           upstream: v3.7.1
         - pulumi: v4.17.0
-          upstream: v3.101.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.16.8
-          upstream: v3.98.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.16.7
-          upstream: v3.92.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.16.6
-          upstream: v3.91.1
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.16.5
           upstream: v3.6.3
         - pulumi: v4.16.4
-          upstream: v3.90.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.16.3
           error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.16.2
@@ -11210,9 +11210,9 @@ bridged:
         - pulumi: v4.16.1
           upstream: v3.6.1
         - pulumi: v4.16.0
-          upstream: v3.74.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.15.1
-          upstream: v3.70.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.15.0
           upstream: v3.6.0
         - pulumi: v4.14.0
@@ -11220,11 +11220,11 @@ bridged:
         - pulumi: v4.13.4
           error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.13.3
-          upstream: v3.59.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.13.2
-          upstream: v0.9.2
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.13.1
-          upstream: v3.47.2
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.13.0
           upstream: v3.5.1
         - pulumi: v4.12.1
@@ -11232,7 +11232,7 @@ bridged:
         - pulumi: v4.12.0
           error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.11.3
-          upstream: v0.4.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.11.2
           error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.11.1
@@ -11246,19 +11246,19 @@ bridged:
         - pulumi: v4.8.1
           error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.8.0
-          upstream: v3.24.1
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.7.0
           upstream: v3.2.0
         - pulumi: v4.6.0
-          upstream: v3.21.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.5.0
-          upstream: v3.21.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.4.2
           upstream: v3.1.2
         - pulumi: v4.4.1
           upstream: v3.1.1
         - pulumi: v4.4.0
-          upstream: v3.19.1
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.3.1
           error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.3.0
@@ -11407,14 +11407,14 @@ bridged:
         - pulumi: v0.1.3
           upstream: v0.4.1
         - pulumi: v0.1.2
-          upstream: v3.89.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v0.1.1
           error: no GitHub release
         - pulumi: v0.1.0
           error: no GitHub release
     signalfx:
         - pulumi: v7.27.0
-          upstream: v3.130.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v7.26.0
           upstream: v9.29.0
         - pulumi: v7.25.0
@@ -11490,7 +11490,7 @@ bridged:
         - pulumi: v7.2.0
           upstream: v9.2.0
         - pulumi: v7.1.8
-          upstream: v9.1.7
+          error: inferred upstream version v9.1.7 is not available from the Terraform registry
         - pulumi: v7.1.7
           upstream: v9.1.6
         - pulumi: v7.1.6
@@ -11502,7 +11502,7 @@ bridged:
         - pulumi: v7.1.3
           upstream: v9.1.2
         - pulumi: v7.1.2
-          upstream: v3.81.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v7.1.1
           upstream: v9.1.1
         - pulumi: v7.1.0
@@ -11510,7 +11510,7 @@ bridged:
         - pulumi: v7.0.2
           upstream: v9.0.1
         - pulumi: v7.0.1
-          upstream: v3.71.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v7.0.0
           upstream: v9.0.0
         - pulumi: v6.1.0
@@ -11635,43 +11635,43 @@ bridged:
           error: no GitHub release
     slack:
         - pulumi: v0.5.0
-          upstream: v3.130.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v0.4.17
-          upstream: v3.128.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v0.4.16
-          upstream: v3.122.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v0.4.15
-          upstream: v3.119.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v0.4.14
-          upstream: v3.115.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v0.4.13
-          upstream: v3.111.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v0.4.12
-          upstream: v3.107.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v0.4.11
-          upstream: v3.103.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v0.4.10
-          upstream: v3.98.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v0.4.9
           error: no GitHub release
         - pulumi: v0.4.8
           error: no GitHub release
         - pulumi: v0.4.7
-          upstream: v3.91.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v0.4.6
-          upstream: v3.88.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v0.4.5
-          upstream: v3.83.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v0.4.4
-          upstream: v3.78.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v0.4.3
-          upstream: v3.71.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v0.4.2
-          upstream: v1.2.2
+          error: inferred upstream version v1.2.2 is not available from the Terraform registry
         - pulumi: v0.4.1
           error: no GitHub release
         - pulumi: v0.4.0
-          upstream: v1.2.0
+          error: inferred upstream version v1.2.0 is not available from the Terraform registry
         - pulumi: v0.3.1
           error: no GitHub release
         - pulumi: v0.3.0
@@ -11686,55 +11686,55 @@ bridged:
           error: no GitHub release
     snowflake:
         - pulumi: v2.18.0
-          upstream: v2.18.0
+          error: inferred upstream version v2.18.0 is not available from the Terraform registry
         - pulumi: v2.17.0
-          upstream: v2.17.0
+          error: inferred upstream version v2.17.0 is not available from the Terraform registry
         - pulumi: v2.16.0
-          upstream: v2.16.0
+          error: inferred upstream version v2.16.0 is not available from the Terraform registry
         - pulumi: v2.15.0
-          upstream: v2.16.0
+          error: inferred upstream version v2.16.0 is not available from the Terraform registry
         - pulumi: v2.14.0
-          upstream: v2.15.0
+          error: inferred upstream version v2.15.0 is not available from the Terraform registry
         - pulumi: v2.13.1
-          upstream: v2.14.1
+          error: inferred upstream version v2.14.1 is not available from the Terraform registry
         - pulumi: v2.13.0
-          upstream: v2.14.0
+          error: inferred upstream version v2.14.0 is not available from the Terraform registry
         - pulumi: v2.12.0
-          upstream: v2.13.0
+          error: inferred upstream version v2.13.0 is not available from the Terraform registry
         - pulumi: v2.11.0
-          upstream: v2.12.0
+          error: inferred upstream version v2.12.0 is not available from the Terraform registry
         - pulumi: v2.10.0
-          upstream: v2.11.0
+          error: inferred upstream version v2.11.0 is not available from the Terraform registry
         - pulumi: v2.9.1
-          upstream: v2.10.1
+          error: inferred upstream version v2.10.1 is not available from the Terraform registry
         - pulumi: v2.9.0
-          upstream: v2.10.0
+          error: inferred upstream version v2.10.0 is not available from the Terraform registry
         - pulumi: v2.8.0
-          upstream: v2.9.0
+          error: inferred upstream version v2.9.0 is not available from the Terraform registry
         - pulumi: v2.7.0
-          upstream: v2.8.0
+          error: inferred upstream version v2.8.0 is not available from the Terraform registry
         - pulumi: v2.6.0
-          upstream: v2.7.0
+          error: inferred upstream version v2.7.0 is not available from the Terraform registry
         - pulumi: v2.5.0
-          upstream: v2.6.0
+          error: inferred upstream version v2.6.0 is not available from the Terraform registry
         - pulumi: v2.4.1
-          upstream: v2.5.0
+          error: inferred upstream version v2.5.0 is not available from the Terraform registry
         - pulumi: v2.4.0
-          upstream: v2.5.0
+          error: inferred upstream version v2.5.0 is not available from the Terraform registry
         - pulumi: v2.3.0
-          upstream: v2.4.0
+          error: inferred upstream version v2.4.0 is not available from the Terraform registry
         - pulumi: v2.2.0
-          upstream: v2.3.0
+          error: inferred upstream version v2.3.0 is not available from the Terraform registry
         - pulumi: v2.1.0
-          upstream: v2.2.0
+          error: inferred upstream version v2.2.0 is not available from the Terraform registry
         - pulumi: v2.0.1
-          upstream: v2.1.1
+          error: inferred upstream version v2.1.1 is not available from the Terraform registry
         - pulumi: v2.0.0
-          upstream: v2.1.0
+          error: inferred upstream version v2.1.0 is not available from the Terraform registry
         - pulumi: v1.3.0
-          upstream: v1.2.1
+          error: inferred upstream version v1.2.1 is not available from the Terraform registry
         - pulumi: v1.2.0
-          upstream: v1.1.0
+          error: inferred upstream version v1.1.0 is not available from the Terraform registry
         - pulumi: v1.1.4
           upstream: v1.0.5
         - pulumi: v1.1.3
@@ -11762,7 +11762,7 @@ bridged:
         - pulumi: v0.58.0
           upstream: v0.95.0
         - pulumi: v0.57.2
-          upstream: v3.89.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v0.57.1
           upstream: v0.94.1
         - pulumi: v0.57.0
@@ -11796,7 +11796,7 @@ bridged:
         - pulumi: v0.46.1
           upstream: v0.83.1
         - pulumi: v0.46.0
-          upstream: v0.83.0
+          error: inferred upstream version v0.83.0 is not available from the Terraform registry
         - pulumi: v0.45.0
           upstream: v0.82.0
         - pulumi: v0.44.0
@@ -11820,7 +11820,7 @@ bridged:
         - pulumi: v0.35.0
           error: no GitHub release
         - pulumi: v0.34.0
-          upstream: v3.60.1
+          upstream: v0.71.0
         - pulumi: v0.33.1
           upstream: v0.70.1
         - pulumi: v0.33.0
@@ -11828,7 +11828,7 @@ bridged:
         - pulumi: v0.32.0
           upstream: v0.70.0
         - pulumi: v0.31.0
-          upstream: v3.54.3
+          upstream: v0.69.0
         - pulumi: v0.30.2
           upstream: v0.68.2
         - pulumi: v0.30.1
@@ -11842,7 +11842,7 @@ bridged:
         - pulumi: v0.27.2
           upstream: v0.66.2
         - pulumi: v0.27.1
-          upstream: v3.49.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v0.27.0
           upstream: v0.66.1
         - pulumi: v0.26.0
@@ -11860,7 +11860,7 @@ bridged:
         - pulumi: v0.21.0
           upstream: v0.61.0
         - pulumi: v0.20.0
-          upstream: v0.60.1
+          error: inferred upstream version v0.60.1 is not available from the Terraform registry
         - pulumi: v0.19.0
           upstream: v0.59.0
         - pulumi: v0.18.1
@@ -11876,13 +11876,13 @@ bridged:
         - pulumi: v0.16.0
           error: no GitHub release
         - pulumi: v0.15.0
-          upstream: v0.53.1
+          error: inferred upstream version v0.53.1 is not available from the Terraform registry
         - pulumi: v0.14.0
           upstream: v0.45.0
         - pulumi: v0.13.2
           error: no GitHub release
         - pulumi: v0.13.1
-          upstream: v3.31.0
+          error: no GitHub release
         - pulumi: v0.13.0
           error: no GitHub release
         - pulumi: v0.12.0
@@ -11908,13 +11908,13 @@ bridged:
         - pulumi: v0.5.0
           error: no GitHub release
         - pulumi: v0.4.2
-          upstream: v0.26.3
+          error: inferred upstream version v0.26.3 is not available from the Terraform registry
         - pulumi: v0.4.1
           error: no GitHub release
         - pulumi: v0.4.0
           error: no GitHub release
         - pulumi: v0.3.6
-          upstream: v0.25.33
+          error: inferred upstream version v0.25.33 is not available from the Terraform registry
         - pulumi: v0.3.5
           error: no GitHub release
         - pulumi: v0.3.4
@@ -11943,7 +11943,7 @@ bridged:
         - pulumi: v1.4.1
           upstream: v1.5.3
         - pulumi: v1.4.0
-          upstream: v3.130.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v1.3.1
           upstream: v1.5.1
         - pulumi: v1.3.0
@@ -11957,17 +11957,17 @@ bridged:
         - pulumi: v1.2.23
           upstream: v1.4.33
         - pulumi: v1.2.22
-          upstream: v3.117.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v1.2.21
           upstream: v1.4.32
         - pulumi: v1.2.20
-          upstream: v3.114.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v1.2.19
           upstream: v1.4.31
         - pulumi: v1.2.18
           error: no GitHub release
         - pulumi: v1.2.17
-          upstream: v3.106.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v1.2.16
           upstream: v1.4.30
         - pulumi: v1.2.15
@@ -11983,15 +11983,15 @@ bridged:
         - pulumi: v1.2.10
           upstream: v1.4.25
         - pulumi: v1.2.9
-          upstream: v3.90.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v1.2.8
           upstream: v1.4.24
         - pulumi: v1.2.7
-          upstream: v3.83.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v1.2.6
-          upstream: v3.78.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v1.2.5
-          upstream: v3.71.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v1.2.4
           error: no GitHub release
         - pulumi: v1.2.3
@@ -12040,7 +12040,7 @@ bridged:
         - pulumi: v3.134.0
           upstream: v1.237.0
         - pulumi: v3.133.0
-          upstream: v3.130.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v3.132.1
           upstream: v1.236.1
         - pulumi: v3.132.0
@@ -12246,7 +12246,7 @@ bridged:
         - pulumi: v3.64.0
           upstream: v1.157.0
         - pulumi: v3.63.0
-          upstream: v3.69.0
+          upstream: v1.156.0
         - pulumi: v3.62.0
           upstream: v1.155.0
         - pulumi: v3.61.1
@@ -12262,7 +12262,7 @@ bridged:
         - pulumi: v3.59.0
           upstream: v1.150.0
         - pulumi: v3.58.1
-          upstream: v3.63.2
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v3.58.0
           upstream: v1.148.0
         - pulumi: v3.57.0
@@ -12274,11 +12274,11 @@ bridged:
         - pulumi: v3.54.0
           upstream: v1.141.0
         - pulumi: v3.53.0
-          upstream: v3.60.1
+          upstream: v1.140.0
         - pulumi: v3.52.0
           upstream: v1.139.0
         - pulumi: v3.51.0
-          upstream: v3.59.0
+          upstream: v1.138.0
         - pulumi: v3.50.0
           upstream: v1.136.0
         - pulumi: v3.49.0
@@ -12312,7 +12312,7 @@ bridged:
         - pulumi: v3.37.0
           upstream: v1.122.2
         - pulumi: v3.36.1
-          upstream: v3.49.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v3.36.0
           upstream: v1.122.0
         - pulumi: v3.35.0
@@ -12457,9 +12457,9 @@ bridged:
           error: no GitHub release
     tailscale:
         - pulumi: v0.28.0
-          upstream: v3.130.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v0.27.1
-          upstream: v3.127.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v0.27.0
           upstream: v0.28.0
         - pulumi: v0.26.0
@@ -12473,7 +12473,7 @@ bridged:
         - pulumi: v0.22.0
           upstream: v0.22.0
         - pulumi: v0.21.1
-          upstream: v3.112.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v0.21.0
           upstream: v0.21.1
         - pulumi: v0.20.0
@@ -12483,7 +12483,7 @@ bridged:
         - pulumi: v0.18.0
           upstream: v0.18.0
         - pulumi: v0.17.5
-          upstream: v3.99.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v0.17.4
           error: no GitHub release
         - pulumi: v0.17.3
@@ -12497,7 +12497,7 @@ bridged:
         - pulumi: v0.16.2
           upstream: v0.16.2
         - pulumi: v0.16.1
-          upstream: v3.86.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v0.16.0
           upstream: v0.16.1
         - pulumi: v0.15.0
@@ -12505,13 +12505,13 @@ bridged:
         - pulumi: v0.14.0
           upstream: v0.14.0
         - pulumi: v0.13.5
-          upstream: v3.74.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v0.13.4
           upstream: v0.13.13
         - pulumi: v0.13.3
-          upstream: v3.65.0
+          error: inferred upstream version v0.13.12 is not available from the Terraform registry
         - pulumi: v0.13.2
-          upstream: v3.60.1
+          upstream: v0.13.11
         - pulumi: v0.13.1
           upstream: v0.13.10
         - pulumi: v0.13.0
@@ -12525,13 +12525,13 @@ bridged:
         - pulumi: v0.11.0
           error: no GitHub release
         - pulumi: v0.10.2
-          upstream: v0.12.2
+          error: inferred upstream version v0.12.2 is not available from the Terraform registry
         - pulumi: v0.10.1
-          upstream: v0.12.1
+          error: inferred upstream version v0.12.1 is not available from the Terraform registry
         - pulumi: v0.10.0
-          upstream: v0.12.0
+          error: inferred upstream version v0.12.0 is not available from the Terraform registry
         - pulumi: v0.9.0
-          upstream: v0.11.1
+          error: inferred upstream version v0.11.1 is not available from the Terraform registry
         - pulumi: v0.8.1
           error: no GitHub release
         - pulumi: v0.8.0
@@ -12539,11 +12539,11 @@ bridged:
         - pulumi: v0.7.1
           error: no GitHub release
         - pulumi: v0.7.0
-          upstream: v0.9.0
+          error: inferred upstream version v0.9.0 is not available from the Terraform registry
         - pulumi: v0.6.0
           error: no GitHub release
         - pulumi: v0.5.0
-          upstream: v0.7.0
+          error: inferred upstream version v0.7.0 is not available from the Terraform registry
         - pulumi: v0.4.0
           error: no GitHub release
         - pulumi: v0.3.0
@@ -12554,45 +12554,45 @@ bridged:
           error: no GitHub release
     tls:
         - pulumi: v5.5.0
-          upstream: v3.130.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v5.4.0
           upstream: v4.3.0
         - pulumi: v5.3.1
-          upstream: v3.125.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v5.3.0
           upstream: v4.2.1
         - pulumi: v5.2.3
-          upstream: v3.117.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v5.2.2
-          upstream: v3.113.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v5.2.1
-          upstream: v3.111.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v5.2.0
           upstream: v4.1.0
         - pulumi: v5.1.1
-          upstream: v3.105.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v5.1.0
-          upstream: v3.101.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v5.0.10
-          upstream: v3.98.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v5.0.9
-          upstream: v3.92.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v5.0.8
           error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v5.0.7
-          upstream: v3.91.1
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v5.0.6
           upstream: v4.0.6
         - pulumi: v5.0.5
-          upstream: v3.90.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v5.0.4
-          upstream: v3.86.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v5.0.3
           error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v5.0.2
-          upstream: v3.79.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v5.0.1
-          upstream: v3.73.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v5.0.0
           upstream: v4.0.5
         - pulumi: v4.11.4
@@ -12602,7 +12602,7 @@ bridged:
         - pulumi: v4.11.2
           error: no GitHub release
         - pulumi: v4.11.1
-          upstream: v3.63.2
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.11.0
           error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.10.0
@@ -12618,13 +12618,13 @@ bridged:
         - pulumi: v4.6.1
           error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.6.0
-          upstream: v3.25.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.5.0
           upstream: v3.4.0
         - pulumi: v4.4.0
-          upstream: v3.23.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.3.0
-          upstream: v3.21.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.2.2
           error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.2.1
@@ -12983,35 +12983,35 @@ bridged:
           error: no GitHub release
     vsphere:
         - pulumi: v4.17.0
-          upstream: v2.16.1
+          error: inferred upstream version v2.16.1 is not available from the Terraform registry
         - pulumi: v4.16.6
-          upstream: v3.130.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.16.5
-          upstream: v2.15.2
+          error: inferred upstream version v2.15.2 is not available from the Terraform registry
         - pulumi: v4.16.4
-          upstream: v2.15.1
+          error: inferred upstream version v2.15.1 is not available from the Terraform registry
         - pulumi: v4.16.3
-          upstream: v2.15.0
+          error: inferred upstream version v2.15.0 is not available from the Terraform registry
         - pulumi: v4.16.2
-          upstream: v2.15.0
+          error: inferred upstream version v2.15.0 is not available from the Terraform registry
         - pulumi: v4.16.1
-          upstream: v2.15.0
+          error: inferred upstream version v2.15.0 is not available from the Terraform registry
         - pulumi: v4.16.0
-          upstream: v2.15.0
+          error: inferred upstream version v2.15.0 is not available from the Terraform registry
         - pulumi: v4.15.1
-          upstream: v2.14.2
+          error: inferred upstream version v2.14.2 is not available from the Terraform registry
         - pulumi: v4.15.0
-          upstream: v2.14.0
+          error: inferred upstream version v2.14.0 is not available from the Terraform registry
         - pulumi: v4.14.0
-          upstream: v2.13.0
+          error: inferred upstream version v2.13.0 is not available from the Terraform registry
         - pulumi: v4.13.2
-          upstream: v3.106.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.13.1
           upstream: v2.11.1
         - pulumi: v4.13.0
           upstream: v2.11.0
         - pulumi: v4.12.2
-          upstream: v3.99.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.12.1
           error: no GitHub release
         - pulumi: v4.12.0
@@ -13033,21 +13033,21 @@ bridged:
         - pulumi: v4.10.2
           upstream: v2.8.2
         - pulumi: v4.10.1
-          upstream: v3.82.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.10.0
           upstream: v2.7.0
         - pulumi: v4.9.2
-          upstream: v3.74.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.9.1
           upstream: v2.6.1
         - pulumi: v4.9.0
           upstream: v2.6.0
         - pulumi: v4.8.1
-          upstream: v3.63.2
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.8.0
           upstream: v2.5.1
         - pulumi: v4.7.0
-          upstream: v3.61.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v4.6.1
           error: no GitHub release
         - pulumi: v4.6.0
@@ -13198,33 +13198,33 @@ bridged:
           error: no GitHub release
     wavefront:
         - pulumi: v3.1.12
-          upstream: v3.119.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v3.1.11
-          upstream: v3.115.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v3.1.10
-          upstream: v3.111.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v3.1.9
-          upstream: v3.107.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v3.1.8
-          upstream: v3.104.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v3.1.7
-          upstream: v3.99.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v3.1.6
           error: no GitHub release
         - pulumi: v3.1.5
           error: no GitHub release
         - pulumi: v3.1.4
-          upstream: v3.91.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v3.1.3
-          upstream: v3.87.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v3.1.2
-          upstream: v3.82.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v3.1.1
-          upstream: v3.77.0
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v3.1.0
           upstream: v5.1.0
         - pulumi: v3.0.4
-          upstream: v3.63.2
+          error: 'failed to parse version from release notes: no upstream version found in commit message'
         - pulumi: v3.0.3
           upstream: v5.0.5
         - pulumi: v3.0.2

--- a/pkg/providermap/versions_sanity_test.go
+++ b/pkg/providermap/versions_sanity_test.go
@@ -1,0 +1,56 @@
+// Copyright 2016-2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package providermap
+
+import (
+	"sort"
+	"testing"
+)
+
+// TestVersionsYAMLNoCrossProviderUpstreamPoisoning is a tripwire for a failure mode where
+// the update-providermap inference records a shared dependency's version (historically the
+// pulumi-terraform-bridge version, e.g. "Upgrade pulumi-terraform-bridge to v3.130.0") as a
+// provider's upstream version. Because such a bump lands across many provider repos at once,
+// the poisoned value shows up as the upstream version of many unrelated providers, which
+// never happens with genuine upstream versions: as of the 2026-07 cleanup the most widely
+// shared legitimate upstream version (v2.4.0) spans 10 providers, while the poisoned
+// v3.130.0 spanned 31. If this test fails, inspect the offending entries in versions.yaml
+// before considering a threshold bump.
+func TestVersionsYAMLNoCrossProviderUpstreamPoisoning(t *testing.T) {
+	t.Parallel()
+	const maxProvidersPerUpstreamVersion = 12
+
+	providersByUpstream := map[ReleaseTag][]string{}
+	for bp, pairs := range refinedVersionMap.Bridged {
+		seen := map[ReleaseTag]bool{}
+		for _, vp := range pairs {
+			if vp.Error != "" || vp.Upstream == "" || seen[vp.Upstream] {
+				continue
+			}
+			seen[vp.Upstream] = true
+			providersByUpstream[vp.Upstream] = append(providersByUpstream[vp.Upstream], string(bp))
+		}
+	}
+
+	for version, providers := range providersByUpstream {
+		if len(providers) > maxProvidersPerUpstreamVersion {
+			sort.Strings(providers)
+			t.Errorf("upstream version %s is recorded for %d different providers (%v); "+
+				"this looks like a shared dependency version (e.g. pulumi-terraform-bridge) "+
+				"misrecorded as an upstream provider version by update-providermap",
+				version, len(providers), providers)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

Go Tests CI has been red since ~May 25. The `update-providermap` inference regex matches "Upgrade pulumi-**terraform**-bridge to v3.130.0" as an upstream provider upgrade, so bridge-only releases recorded the bridge version as the provider's upstream version — 455 entries across 51 providers. `TestUpgradeInstance` resolved "latest" for `hashicorp/random` to the nonexistent 3.130.0 and failed to download it.

## Changes

- **Parser fix**: mask `pulumi-terraform-bridge` / `terraform-plugin-*` names before extracting versions from commit messages and release notes.
- **Data repair**: purged and re-inferred all 455 poisoned entries in `versions.yaml` — 41 corrected to their real upstream versions, 414 became error entries (bridge-only releases; lookups skip these), 19 new releases picked up. All upstream versions now verified to exist in the Terraform registry.
- **Updater hardening**: `update-providermap` validates inferred versions against the registry, and re-clones its git cache when it's corrupted.
- **Panic fix**: `RecommendPulumiProvider` no longer panics for providers with only error entries (e.g. `slack`); it falls back to the newest Pulumi release.
- **Tripwire test**: fails if one upstream version spans >12 providers — the poisoning signature.

## Testing

`go test ./...` fully green, including the previously failing `TestUpgradeInstance`. New unit tests for the parser, the all-error fallback, and the tripwire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)