### PR TITLE
Add renovate.json5 to auto-bump pulumi-terraform-bridge

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,17 @@
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  extends: ["github>pulumi/renovate-config//default.json5"],
+  packageRules: [
+    {
+      // The org preset gates bridge upgrades behind Dependency Dashboard
+      // approval and runs `make renovate` (this repo has no Makefile).
+      // Override: open bridge PRs automatically and automerge on green CI,
+      // like other first-party Pulumi deps.
+      matchManagers: ["gomod"],
+      matchPackageNames: ["github.com/pulumi/pulumi-terraform-bridge/v3"],
+      dependencyDashboardApproval: false,
+      minimumReleaseAge: "0 days",
+      postUpgradeTasks: { commands: [] },
+    },
+  ],
+}


### PR DESCRIPTION
Renovate already runs here via the org-wide `pulumi-renovate` app, but the shared preset gates `pulumi-terraform-bridge/v3` upgrades behind Dependency Dashboard approval and a `make renovate` post-upgrade task this repo doesn't have.

This adds a repo-local `renovate.json5` overriding that rule so bridge upgrade PRs open automatically and automerge on green CI, like other first-party Pulumi deps.

Validated with `renovate-config-validator`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)